### PR TITLE
Hide volunteer matching subtitle on mobile devices

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
               <span className="text-lg font-medium leading-7 text-text-dark">
                 ボランティアマッチング
               </span>
-              <span className="text-xs leading-4 text-text-body">
+              <span className="hidden text-xs leading-4 text-text-body sm:block">
                 あなたにぴったりの活動を見つけよう
               </span>
             </div>


### PR DESCRIPTION
## Summary
Updated the volunteer matching section header to hide the subtitle text on mobile devices and only display it on small screens and larger.

## Key Changes
- Added `hidden sm:block` classes to the subtitle span in the volunteer matching header
- This ensures the descriptive text "あなたにぴったりの活動を見つけよう" (Find the perfect activity for you) is only visible on sm (640px) and larger breakpoints
- Improves mobile UX by reducing visual clutter on smaller screens while maintaining the full description on desktop

## Implementation Details
- Used Tailwind CSS responsive utilities (`hidden` and `sm:block`) to control visibility
- The main heading "ボランティアマッチング" (Volunteer Matching) remains visible on all screen sizes
- This is a mobile-first responsive design improvement

https://claude.ai/code/session_013hAdF4YSoXRgWLN8rLkxRq