### PR TITLE
モバイルUIでヘッダーのサブタイトルを非表示に修正 (#8)

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
               <span className="text-lg font-medium leading-7 text-text-dark">
                 ボランティアマッチング
               </span>
-              <span className="text-xs leading-4 text-text-body">
+              <span className="hidden text-xs leading-4 text-text-body sm:block">
                 あなたにぴったりの活動を見つけよう
               </span>
             </div>


### PR DESCRIPTION
スマートフォン幅（sm未満）でヘッダーの「あなたにぴったりの活動を見つけよう」が
表示されないよう hidden sm:block クラスを追加。

https://claude.ai/code/session_013hAdF4YSoXRgWLN8rLkxRq