### PR TITLE
Add toast notifications for auth callbacks and account deletion

### DIFF
--- a/app/src/app/(auth)/login/page.test.tsx
+++ b/app/src/app/(auth)/login/page.test.tsx
@@ -1,17 +1,26 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import LoginPage from "./page";
+
+const mocks = vi.hoisted(() => ({
+  signInWithOAuth: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
     auth: {
-      signInWithOAuth: vi.fn(),
+      signInWithOAuth: mocks.signInWithOAuth,
     },
   }),
 }));
 
 describe("LoginPage", () => {
+  beforeEach(() => {
+    mocks.signInWithOAuth.mockClear();
+    window.history.replaceState(null, "", "http://localhost:3000/login");
+  });
+
   it("メールログインUIを表示せずGoogleログインだけ表示する", () => {
     render(<LoginPage />);
 
@@ -20,5 +29,25 @@ describe("LoginPage", () => {
     expect(screen.queryByLabelText("パスワード")).toBeNull();
     expect(screen.queryByRole("button", { name: "ログイン" })).toBeNull();
     expect(screen.queryByText("または")).toBeNull();
+  });
+
+  it("next パラメータがある場合、Googleログインの callback URL に引き継ぐ", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "http://localhost:3000/login?next=/mypage"
+    );
+    render(<LoginPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Googleでログイン" }));
+
+    await waitFor(() => {
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: "google",
+        options: {
+          redirectTo: "http://localhost:3000/auth/callback?next=%2Fmypage",
+        },
+      });
+    });
   });
 });

--- a/app/src/app/(auth)/login/page.tsx
+++ b/app/src/app/(auth)/login/page.tsx
@@ -5,6 +5,22 @@ import { Card, CardHeader, CardContent } from "@/app/components/ui/Card";
 import { GoogleAuthButton } from "@/app/components/auth/GoogleAuthButton";
 import { AuthFooter } from "@/app/components/auth/AuthFooter";
 
+function isSafeInternalPath(value: string | null): value is string {
+  return !!value && value.startsWith("/") && !value.startsWith("//");
+}
+
+function buildAuthCallbackUrl() {
+  const origin = location.origin.replace("//0.0.0.0:", "//localhost:");
+  const callbackUrl = new URL("/auth/callback", origin);
+  const next = new URLSearchParams(location.search).get("next");
+
+  if (isSafeInternalPath(next)) {
+    callbackUrl.searchParams.set("next", next);
+  }
+
+  return callbackUrl.toString();
+}
+
 export default function LoginPage() {
   // メール認証を再開する場合は、useState/FormEvent とメールログインフォームを戻す。
   // const [email, setEmail] = useState("");
@@ -14,12 +30,10 @@ export default function LoginPage() {
 
   const handleGoogleLogin = async () => {
     const supabase = createClient();
-    // 0.0.0.0 でアクセスした場合は localhost に補正（Supabase Redirect URLs との一致のため）
-    const origin = location.origin.replace("//0.0.0.0:", "//localhost:");
     await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo: `${origin}/auth/callback`,
+        redirectTo: buildAuthCallbackUrl(),
       },
     });
   };

--- a/app/src/app/auth/callback/route.test.ts
+++ b/app/src/app/auth/callback/route.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+const mocks = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: {
+      exchangeCodeForSession: mocks.exchangeCodeForSession,
+    },
+  }),
+}));
+
+describe("auth callback route", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("セッション交換成功時はログイン成功トースト付きで next にリダイレクトする", async () => {
+    mocks.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+    const response = await GET(
+      new Request(
+        "http://0.0.0.0:3000/auth/callback?code=ok&next=%2Fmypage%3Ftab%3Dprofile"
+      )
+    );
+
+    expect(mocks.exchangeCodeForSession).toHaveBeenCalledWith("ok");
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/mypage?tab=profile&toast=login-success"
+    );
+  });
+
+  it("セッション交換失敗時はログイン失敗トースト用パラメータ付きでログイン画面へ戻す", async () => {
+    mocks.exchangeCodeForSession.mockResolvedValueOnce({
+      error: { name: "AuthApiError", message: "bad request", status: 400 },
+    });
+
+    const response = await GET(
+      new Request("http://0.0.0.0:3000/auth/callback?code=ng")
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/login?error=auth"
+    );
+  });
+
+  it("next が外部 URL の場合はトップへフォールバックする", async () => {
+    mocks.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+    const response = await GET(
+      new Request(
+        "http://0.0.0.0:3000/auth/callback?code=ok&next=https%3A%2F%2Fevil.example%2F"
+      )
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/?toast=login-success"
+    );
+  });
+});

--- a/app/src/app/auth/callback/route.ts
+++ b/app/src/app/auth/callback/route.ts
@@ -1,6 +1,30 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+function normalizeOrigin(origin: string) {
+  return origin.replace("//0.0.0.0:", "//localhost:");
+}
+
+function getSafeNextPath(next: string | null) {
+  if (next && next.startsWith("/") && !next.startsWith("//")) {
+    return next;
+  }
+
+  return "/";
+}
+
+function buildLoginSuccessUrl(origin: string, next: string | null) {
+  const redirectUrl = new URL(getSafeNextPath(next), origin);
+  redirectUrl.searchParams.set("toast", "login-success");
+  return redirectUrl.toString();
+}
+
+function buildLoginErrorUrl(origin: string) {
+  const redirectUrl = new URL("/login", origin);
+  redirectUrl.searchParams.set("error", "auth");
+  return redirectUrl.toString();
+}
+
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");
@@ -8,7 +32,7 @@ export async function GET(request: Request) {
   const authErrorDescription = requestUrl.searchParams.get("error_description");
   const next = requestUrl.searchParams.get("next") ?? "/";
   // 0.0.0.0 でアクセスした場合は localhost に補正（Docker開発環境対応）
-  const origin = requestUrl.origin.replace("//0.0.0.0:", "//localhost:");
+  const origin = normalizeOrigin(requestUrl.origin);
 
   if (authError) {
     console.error("[AuthCallback] OAuthプロバイダ認証エラー:", {
@@ -21,7 +45,7 @@ export async function GET(request: Request) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      return NextResponse.redirect(buildLoginSuccessUrl(origin, next));
     }
 
     console.error("[AuthCallback] セッション交換エラー:", {
@@ -32,5 +56,5 @@ export async function GET(request: Request) {
   }
 
   // 認証エラー時はログインページにリダイレクト
-  return NextResponse.redirect(`${origin}/login?error=auth`);
+  return NextResponse.redirect(buildLoginErrorUrl(origin));
 }

--- a/app/src/app/components/ui/ToastProvider.test.tsx
+++ b/app/src/app/components/ui/ToastProvider.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ToastProvider, useToast } from "@/app/components/ui/ToastProvider";
+
+const navigationState = vi.hoisted(() => ({
+  pathname: "/login",
+  search: "",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigationState.pathname,
+  useSearchParams: () => new URLSearchParams(navigationState.search),
+}));
+
+function ManualToastButton() {
+  const { showToast } = useToast();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        showToast({
+          type: "success",
+          title: "保存しました",
+          description: "変更内容を反映しました。",
+        })
+      }
+    >
+      通知する
+    </button>
+  );
+}
+
+describe("ToastProvider", () => {
+  beforeEach(() => {
+    navigationState.pathname = "/login";
+    navigationState.search = "";
+    window.history.replaceState(null, "", "/login");
+  });
+
+  it("accountDeleted パラメータから削除完了トーストを表示し、対象パラメータだけ削除する", async () => {
+    navigationState.search = "accountDeleted=1&next=%2Fmypage";
+    window.history.replaceState(
+      null,
+      "",
+      "/login?accountDeleted=1&next=%2Fmypage"
+    );
+
+    render(
+      <ToastProvider>
+        <div>ログインページ</div>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByText("アカウントを削除しました")).toBeDefined();
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.has("accountDeleted")).toBe(false);
+    expect(searchParams.get("next")).toBe("/mypage");
+  });
+
+  it("error=auth パラメータからログイン失敗トーストを表示する", async () => {
+    navigationState.search = "error=auth";
+    window.history.replaceState(null, "", "/login?error=auth");
+
+    render(
+      <ToastProvider>
+        <div>ログインページ</div>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByText("ログインに失敗しました")).toBeDefined();
+  });
+
+  it("クライアント遷移後に URL パラメータが付いた場合もトーストを表示する", async () => {
+    const { rerender } = render(
+      <ToastProvider>
+        <div>ログインページ</div>
+      </ToastProvider>
+    );
+
+    expect(screen.queryByText("アカウントを削除しました")).toBeNull();
+
+    navigationState.search = "accountDeleted=1";
+    window.history.replaceState(null, "", "/login?accountDeleted=1");
+
+    rerender(
+      <ToastProvider>
+        <div>ログインページ</div>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByText("アカウントを削除しました")).toBeDefined();
+    expect(new URLSearchParams(window.location.search).has("accountDeleted")).toBe(
+      false
+    );
+  });
+
+  it("useToast から手動でトーストを表示できる", async () => {
+    render(
+      <ToastProvider>
+        <ManualToastButton />
+      </ToastProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "通知する" }));
+
+    expect(await screen.findByText("保存しました")).toBeDefined();
+    expect(screen.getByText("変更内容を反映しました。")).toBeDefined();
+  });
+});

--- a/app/src/app/components/ui/ToastProvider.tsx
+++ b/app/src/app/components/ui/ToastProvider.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import {
+  createContext,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { CheckCircle2, X, XCircle } from "lucide-react";
+
+type ToastType = "success" | "error";
+
+export interface ToastInput {
+  type: ToastType;
+  title: string;
+  description?: string;
+  durationMs?: number;
+}
+
+interface Toast extends ToastInput {
+  id: string;
+}
+
+interface ToastContextValue {
+  showToast: (toast: ToastInput) => void;
+}
+
+interface UrlToastResult {
+  toasts: ToastInput[];
+  consumedParams: string[];
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+const AUTO_DISMISS_MS = 4000;
+
+let toastId = 0;
+
+function nextToastId() {
+  toastId += 1;
+  return `toast-${toastId}`;
+}
+
+function collectUrlToasts(searchParams: URLSearchParams): UrlToastResult {
+  const toasts: ToastInput[] = [];
+  const consumedParams: string[] = [];
+
+  if (searchParams.get("toast") === "login-success") {
+    toasts.push({
+      type: "success",
+      title: "ログインしました",
+      description: "ボランティーへようこそ。",
+    });
+    consumedParams.push("toast");
+  }
+
+  if (searchParams.get("error") === "auth") {
+    toasts.push({
+      type: "error",
+      title: "ログインに失敗しました",
+      description: "時間をおいてもう一度お試しください。",
+    });
+    consumedParams.push("error");
+  }
+
+  if (searchParams.get("accountDeleted") === "1") {
+    toasts.push({
+      type: "success",
+      title: "アカウントを削除しました",
+      description: "ご利用ありがとうございました。",
+    });
+    consumedParams.push("accountDeleted");
+  }
+
+  return { toasts, consumedParams };
+}
+
+function removeConsumedUrlParams(params: string[]) {
+  if (params.length === 0) return;
+
+  const url = new URL(window.location.href);
+  params.forEach((param) => url.searchParams.delete(param));
+
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `${url.pathname}${url.search}${url.hash}`
+  );
+}
+
+function ToastUrlObserver({
+  showToast,
+}: {
+  showToast: (toast: ToastInput) => void;
+}) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  const lastHandledSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const signature = `${pathname}?${search}`;
+    const { toasts, consumedParams } = collectUrlToasts(
+      new URLSearchParams(search)
+    );
+
+    if (toasts.length === 0) {
+      lastHandledSignatureRef.current = null;
+      return;
+    }
+
+    if (lastHandledSignatureRef.current === signature) {
+      return;
+    }
+
+    lastHandledSignatureRef.current = signature;
+    toasts.forEach((toast) => showToast(toast));
+    removeConsumedUrlParams(consumedParams);
+  }, [pathname, search, showToast]);
+
+  return null;
+}
+
+function SuspendedToastUrlObserver({
+  showToast,
+}: {
+  showToast: (toast: ToastInput) => void;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <ToastUrlObserver showToast={showToast} />
+    </Suspense>
+  );
+}
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: string) => void;
+}) {
+  useEffect(() => {
+    if (toast.durationMs === 0) return;
+
+    const timeoutId = window.setTimeout(
+      () => onDismiss(toast.id),
+      toast.durationMs ?? AUTO_DISMISS_MS
+    );
+
+    return () => window.clearTimeout(timeoutId);
+  }, [onDismiss, toast.durationMs, toast.id]);
+
+  const Icon = toast.type === "success" ? CheckCircle2 : XCircle;
+  const iconClass =
+    toast.type === "success" ? "text-primary" : "text-red-600";
+
+  return (
+    <div
+      role={toast.type === "error" ? "alert" : "status"}
+      aria-live={toast.type === "error" ? "assertive" : "polite"}
+      className="flex items-start gap-3 rounded-lg border border-card-border bg-white px-4 py-3 text-text-dark shadow-lg"
+    >
+      <Icon className={`mt-0.5 size-5 shrink-0 ${iconClass}`} />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-bold leading-5">{toast.title}</p>
+        {toast.description && (
+          <p className="mt-1 text-sm leading-5 text-text-body">
+            {toast.description}
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => onDismiss(toast.id)}
+        aria-label="通知を閉じる"
+        className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-lg text-text-body hover:bg-tab-bg hover:text-text-dark"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((toast: ToastInput) => {
+    setToasts((currentToasts) => [
+      ...currentToasts,
+      { ...toast, id: nextToastId() },
+    ]);
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((currentToasts) =>
+      currentToasts.filter((toast) => toast.id !== id)
+    );
+  }, []);
+
+  const value = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <SuspendedToastUrlObserver showToast={showToast} />
+      <div className="fixed top-4 right-4 z-50 flex w-[calc(100%-2rem)] max-w-sm flex-col gap-3 sm:top-6 sm:right-6">
+        {toasts.map((toast) => (
+          <ToastItem
+            key={toast.id}
+            toast={toast}
+            onDismiss={dismissToast}
+          />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast は ToastProvider の内側で使用してください。");
+  }
+
+  return context;
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_JP } from "next/font/google";
+import { ToastProvider } from "@/app/components/ui/ToastProvider";
 import "./globals.css";
 
 const notoSansJP = Noto_Sans_JP({
@@ -22,7 +23,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <body className={`${notoSansJP.variable} antialiased`} suppressHydrationWarning>{children}</body>
+      <body
+        className={`${notoSansJP.variable} antialiased`}
+        suppressHydrationWarning
+      >
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/app/src/app/mypage/DeleteAccountForm.test.tsx
+++ b/app/src/app/mypage/DeleteAccountForm.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteAccountForm } from "./DeleteAccountForm";
+
+const mocks = vi.hoisted(() => ({
+  actionState: { error: null as string | null },
+  formAction: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useActionState: () => [mocks.actionState, mocks.formAction, false],
+  };
+});
+
+vi.mock("@/app/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: mocks.showToast,
+  }),
+}));
+
+vi.mock("@/lib/mypage/actions", () => ({
+  deleteMyAccount: vi.fn(),
+}));
+
+describe("DeleteAccountForm", () => {
+  beforeEach(() => {
+    mocks.actionState.error = null;
+    mocks.showToast.mockClear();
+  });
+
+  it("削除失敗時はインラインエラーに加えてエラートーストを表示する", async () => {
+    mocks.actionState.error = "確認欄に「削除する」と入力してください。";
+
+    render(<DeleteAccountForm />);
+
+    expect(
+      screen.getByText("確認欄に「削除する」と入力してください。")
+    ).toBeDefined();
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith({
+        type: "error",
+        title: "アカウント削除に失敗しました",
+        description: "確認欄に「削除する」と入力してください。",
+      });
+    });
+  });
+});

--- a/app/src/app/mypage/DeleteAccountForm.tsx
+++ b/app/src/app/mypage/DeleteAccountForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useEffect } from "react";
 import { AlertTriangle, Trash2 } from "lucide-react";
 import { Button } from "@/app/components/ui/Button";
+import { useToast } from "@/app/components/ui/ToastProvider";
 import { deleteMyAccount } from "@/lib/mypage/actions";
 import type { DeleteAccountState } from "@/lib/mypage/types";
 
@@ -17,6 +18,17 @@ export function DeleteAccountForm() {
     deleteMyAccount,
     initialState
   );
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    if (!state.error) return;
+
+    showToast({
+      type: "error",
+      title: "アカウント削除に失敗しました",
+      description: state.error,
+    });
+  }, [showToast, state.error]);
 
   return (
     <form action={formAction} className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- ログイン成功・失敗・アカウント削除完了の通知を ToastProvider で共通化
- `/login` の `next` パラメータを安全に Google OAuth の callback に引き継ぎ
- `/auth/callback` のリダイレクト先を安全に構築し、外部 URL をフォールバック
- アカウント削除失敗時はインラインエラーに加えてエラートーストを表示
- 関連する URL トーストの表示・削除・手動表示をテストで追加

## Testing
- 新規/更新テストを追加して、ログイン callback、ToastProvider、削除フォームの挙動を検証
- UI と URL パラメータの連携を含む動作をカバー
- Not run (not requested)