### PR TITLE
カテゴリ・地域でおすすめ案件を絞り込めるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ lint: ## ESLintをコンテナ内で実行（コード品質チェック）
 	$(COMPOSE) run --rm $(SERVICE) npm run lint
 
 type-check: ## TypeScriptの型チェックをコンテナ内で実行（npm run buildで検証）
-	$(COMPOSE) run --rm $(SERVICE) npm run build
+	$(COMPOSE) run --rm -e NODE_ENV=production $(SERVICE) npm run build
 
 build-next: ## Next.jsの本番ビルドをホストマシンで実行（本番デプロイ前の検証用）
 	cd $(APP_DIR) && npm run build

--- a/app/src/app/(auth)/signup/complete/page.tsx
+++ b/app/src/app/(auth)/signup/complete/page.tsx
@@ -1,14 +1,9 @@
-"use client";
-
+import Link from "next/link";
 import { Mail } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/app/components/ui/Card";
-import { Button } from "@/app/components/ui/Button";
 import { ProgressBar } from "@/app/components/ui/ProgressBar";
 
 export default function SignupCompletePage() {
-  const router = useRouter();
-
   return (
     <div className="flex flex-1 items-center justify-center px-4 py-12">
       <Card className="w-full max-w-[640px]">
@@ -28,13 +23,12 @@ export default function SignupCompletePage() {
                 メール内のリンクをクリックして登録を完了してください。
               </p>
             </div>
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={() => router.push("/login")}
+            <Link
+              href="/login"
+              className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-card-border bg-background px-4 text-sm font-medium text-text-dark transition-colors hover:bg-tab-bg"
             >
               ログインページへ
-            </Button>
+            </Link>
           </div>
         </CardContent>
       </Card>

--- a/app/src/app/(auth)/signup/constants.ts
+++ b/app/src/app/(auth)/signup/constants.ts
@@ -1,0 +1,2 @@
+/** Step 1 で一時保存するキー（メールアドレスのみ） */
+export const SIGNUP_TEMP_KEY = "volunty_signup_temp";

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -8,9 +8,6 @@ import { ProgressBar } from "@/app/components/ui/ProgressBar";
 import { GoogleAuthButton } from "@/app/components/auth/GoogleAuthButton";
 import { AuthFooter } from "@/app/components/auth/AuthFooter";
 
-/** Step 1 で一時保存するキー（メールアドレスのみ） */
-export const SIGNUP_TEMP_KEY = "volunty_signup_temp";
-
 export default function SignupPage() {
   const router = useRouter();
   // メール認証を再開する場合は、useState/FormEvent とメール登録フォームを戻す。

--- a/app/src/app/(auth)/signup/profile/page.test.tsx
+++ b/app/src/app/(auth)/signup/profile/page.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import SignupProfilePage from "./page";
-import { SIGNUP_TEMP_KEY } from "@/app/(auth)/signup/page";
+import { SIGNUP_TEMP_KEY } from "@/app/(auth)/signup/constants";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),

--- a/app/src/app/(auth)/signup/profile/page.tsx
+++ b/app/src/app/(auth)/signup/profile/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardHeader, CardContent } from "@/app/components/ui/Card";
 import { Button } from "@/app/components/ui/Button";
 import { Input } from "@/app/components/ui/Input";
 import { ProgressBar } from "@/app/components/ui/ProgressBar";
-import { SIGNUP_TEMP_KEY } from "@/app/(auth)/signup/page";
+import { SIGNUP_TEMP_KEY } from "@/app/(auth)/signup/constants";
 
 /** ステップ数に基づくプログレスバー値 */
 const STEP2_PROGRESS = Math.round((2 / 3) * 100);

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 :root {
+  --font-noto-sans-jp: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;
   --background: #ffeee2;
   --foreground: #6d2700;
   --primary: #fb5b01;
@@ -59,6 +60,7 @@
 }
 
 body {
+  font-family: var(--font-noto-sans-jp);
   background: var(--background);
   color: var(--foreground);
 }

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,14 +1,6 @@
 import type { Metadata } from "next";
-import { Noto_Sans_JP } from "next/font/google";
 import { ToastProvider } from "@/app/components/ui/ToastProvider";
 import "./globals.css";
-
-const notoSansJP = Noto_Sans_JP({
-  variable: "--font-noto-sans-jp",
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "ボランティー | あなたにぴったりの活動を見つけよう",
@@ -23,10 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <body
-        className={`${notoSansJP.variable} antialiased`}
-        suppressHydrationWarning
-      >
+      <body className="antialiased" suppressHydrationWarning>
         <ToastProvider>{children}</ToastProvider>
       </body>
     </html>

--- a/app/src/app/recommendations/components/RecommendationFilters.test.tsx
+++ b/app/src/app/recommendations/components/RecommendationFilters.test.tsx
@@ -1,8 +1,20 @@
-import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RecommendationFilters } from "./RecommendationFilters"
 
+const pushMock = vi.fn()
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}))
+
 describe("RecommendationFilters", () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+  })
+
   it("地域と参加形態を選択式フィルタとして表示する", () => {
     render(
       <RecommendationFilters
@@ -28,5 +40,34 @@ describe("RecommendationFilters", () => {
     expect((participationModeSelect as HTMLSelectElement).value).toBe("online")
     expect(screen.getByRole("option", { name: "オンライン" })).toBeTruthy()
     expect(screen.getByRole("option", { name: "オフライン" })).toBeTruthy()
+  })
+
+  it("検索送信中はローディング表示に切り替える", () => {
+    render(<RecommendationFilters filters={{}} />)
+
+    fireEvent.change(screen.getByRole("combobox", { name: "カテゴリ" }), {
+      target: { value: "地域活動" },
+    })
+    fireEvent.change(screen.getByRole("combobox", { name: "地域" }), {
+      target: { value: "練馬区" },
+    })
+    fireEvent.change(screen.getByRole("combobox", { name: "参加形態" }), {
+      target: { value: "online" },
+    })
+
+    fireEvent.submit(
+      screen.getByRole("form", { name: "おすすめ案件フィルター" })
+    )
+
+    const expectedParams = new URLSearchParams({
+      category: "地域活動",
+      region: "練馬区",
+      participationMode: "online",
+    }).toString()
+
+    expect(pushMock).toHaveBeenCalledWith(`/recommendations?${expectedParams}`)
+    expect(
+      screen.getByRole("button", { name: "検索中" }).getAttribute("disabled")
+    ).not.toBeNull()
   })
 })

--- a/app/src/app/recommendations/components/RecommendationFilters.test.tsx
+++ b/app/src/app/recommendations/components/RecommendationFilters.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { RecommendationFilters } from "./RecommendationFilters"
+
+describe("RecommendationFilters", () => {
+  it("地域と参加形態を選択式フィルタとして表示する", () => {
+    render(
+      <RecommendationFilters
+        filters={{
+          category: "地域活動",
+          region: "練馬区",
+          participationMode: "online",
+        }}
+      />
+    )
+
+    const regionSelect = screen.getByRole("combobox", { name: "地域" })
+    const participationModeSelect = screen.getByRole("combobox", {
+      name: "参加形態",
+    })
+
+    expect(regionSelect.getAttribute("name")).toBe("region")
+    expect((regionSelect as HTMLSelectElement).value).toBe("練馬区")
+    expect(screen.getByRole("option", { name: "八王子市" })).toBeTruthy()
+    expect(participationModeSelect.getAttribute("name")).toBe(
+      "participationMode"
+    )
+    expect((participationModeSelect as HTMLSelectElement).value).toBe("online")
+    expect(screen.getByRole("option", { name: "オンライン" })).toBeTruthy()
+    expect(screen.getByRole("option", { name: "オフライン" })).toBeTruthy()
+  })
+})

--- a/app/src/app/recommendations/components/RecommendationFilters.tsx
+++ b/app/src/app/recommendations/components/RecommendationFilters.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link"
+import { Search, X } from "lucide-react"
+import type { RecommendationFilters as RecommendationFiltersType } from "@/lib/recommendations/types"
+
+const CATEGORY_OPTIONS = [
+  "環境保全",
+  "地域活動",
+  "教育",
+  "子ども支援",
+  "居場所づくり",
+  "IT支援",
+  "高齢者支援",
+  "障がい者サポート",
+]
+
+interface RecommendationFiltersProps {
+  filters: RecommendationFiltersType
+}
+
+/**
+ * おすすめ案件一覧のカテゴリ・地域フィルタ。
+ * GET パラメータで絞り込み条件をページへ渡す。
+ */
+export function RecommendationFilters({ filters }: RecommendationFiltersProps) {
+  return (
+    <form
+      method="get"
+      className="mb-6 grid gap-4 rounded-[10px] border border-card-border bg-white p-4 shadow-sm sm:grid-cols-[1fr_1fr_auto] sm:items-end"
+    >
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="category"
+          className="text-sm font-medium text-text-dark"
+        >
+          カテゴリ
+        </label>
+        <select
+          id="category"
+          name="category"
+          defaultValue={filters.category ?? ""}
+          className="h-11 rounded-lg border border-input-border bg-white px-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+        >
+          <option value="">すべて</option>
+          {CATEGORY_OPTIONS.map((category) => (
+            <option key={category} value={category}>
+              {category}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="region" className="text-sm font-medium text-text-dark">
+          地域
+        </label>
+        <input
+          id="region"
+          name="region"
+          type="text"
+          defaultValue={filters.region ?? ""}
+          placeholder="例: 渋谷区、東京都、オンライン"
+          className="h-11 rounded-lg border border-input-border bg-white px-3 text-sm text-text-dark placeholder:text-text-body focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          className="flex h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark sm:flex-none"
+        >
+          <Search className="size-4" />
+          絞り込む
+        </button>
+        <Link
+          href="/recommendations"
+          className="flex h-11 items-center justify-center gap-2 rounded-lg border border-card-border px-4 text-sm font-medium text-text-body hover:bg-background"
+        >
+          <X className="size-4" />
+          クリア
+        </Link>
+      </div>
+    </form>
+  )
+}

--- a/app/src/app/recommendations/components/RecommendationFilters.tsx
+++ b/app/src/app/recommendations/components/RecommendationFilters.tsx
@@ -13,6 +13,40 @@ const CATEGORY_OPTIONS = [
   "障がい者サポート",
 ]
 
+const REGION_OPTIONS = [
+  "渋谷区",
+  "新宿区",
+  "世田谷区",
+  "練馬区",
+  "杉並区",
+  "中野区",
+  "豊島区",
+  "品川区",
+  "港区",
+  "千代田区",
+  "中央区",
+  "台東区",
+  "墨田区",
+  "江東区",
+  "目黒区",
+  "大田区",
+  "板橋区",
+  "足立区",
+  "葛飾区",
+  "江戸川区",
+  "八王子市",
+  "町田市",
+  "立川市",
+  "三鷹市",
+  "武蔵野市",
+  "東京都",
+]
+
+const PARTICIPATION_MODE_OPTIONS = [
+  { value: "online", label: "オンライン" },
+  { value: "offline", label: "オフライン" },
+] as const
+
 interface RecommendationFiltersProps {
   filters: RecommendationFiltersType
 }
@@ -25,7 +59,7 @@ export function RecommendationFilters({ filters }: RecommendationFiltersProps) {
   return (
     <form
       method="get"
-      className="mb-6 grid gap-4 rounded-[10px] border border-card-border bg-white p-4 shadow-sm sm:grid-cols-[1fr_1fr_auto] sm:items-end"
+      className="mb-6 grid gap-4 rounded-[10px] border border-card-border bg-white p-4 shadow-sm sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1fr_auto] lg:items-end"
     >
       <div className="flex flex-col gap-1">
         <label
@@ -53,17 +87,44 @@ export function RecommendationFilters({ filters }: RecommendationFiltersProps) {
         <label htmlFor="region" className="text-sm font-medium text-text-dark">
           地域
         </label>
-        <input
+        <select
           id="region"
           name="region"
-          type="text"
           defaultValue={filters.region ?? ""}
-          placeholder="例: 渋谷区、東京都、オンライン"
-          className="h-11 rounded-lg border border-input-border bg-white px-3 text-sm text-text-dark placeholder:text-text-body focus:outline-none focus:ring-2 focus:ring-primary/30"
-        />
+          className="h-11 rounded-lg border border-input-border bg-white px-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+        >
+          <option value="">すべて</option>
+          {REGION_OPTIONS.map((region) => (
+            <option key={region} value={region}>
+              {region}
+            </option>
+          ))}
+        </select>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="participationMode"
+          className="text-sm font-medium text-text-dark"
+        >
+          参加形態
+        </label>
+        <select
+          id="participationMode"
+          name="participationMode"
+          defaultValue={filters.participationMode ?? ""}
+          className="h-11 rounded-lg border border-input-border bg-white px-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+        >
+          <option value="">すべて</option>
+          {PARTICIPATION_MODE_OPTIONS.map((mode) => (
+            <option key={mode.value} value={mode.value}>
+              {mode.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex gap-2 sm:col-span-2 lg:col-span-1">
         <button
           type="submit"
           className="flex h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark sm:flex-none"

--- a/app/src/app/recommendations/components/RecommendationFilters.tsx
+++ b/app/src/app/recommendations/components/RecommendationFilters.tsx
@@ -1,5 +1,9 @@
+"use client"
+
 import Link from "next/link"
-import { Search, X } from "lucide-react"
+import { Loader2, Search, X } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { type FormEvent, useState } from "react"
 import type { RecommendationFilters as RecommendationFiltersType } from "@/lib/recommendations/types"
 
 const CATEGORY_OPTIONS = [
@@ -51,14 +55,66 @@ interface RecommendationFiltersProps {
   filters: RecommendationFiltersType
 }
 
+interface SearchableFilters {
+  category: string
+  region: string
+  participationMode: string
+}
+
+function readStringFormValue(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value : ""
+}
+
+function createFilterQuery(filters: SearchableFilters) {
+  const params = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === "") continue
+    params.set(key, value)
+  }
+
+  return params.toString()
+}
+
 /**
  * おすすめ案件一覧のカテゴリ・地域フィルタ。
  * GET パラメータで絞り込み条件をページへ渡す。
  */
 export function RecommendationFilters({ filters }: RecommendationFiltersProps) {
+  const router = useRouter()
+  const [searchingQuery, setSearchingQuery] = useState<string | null>(null)
+  const currentQuery = createFilterQuery({
+    category: filters.category ?? "",
+    region: filters.region ?? "",
+    participationMode: filters.participationMode ?? "",
+  })
+  const isSearching = searchingQuery !== null && searchingQuery !== currentQuery
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const formData = new FormData(event.currentTarget)
+    const nextFilters = {
+      category: readStringFormValue(formData, "category"),
+      region: readStringFormValue(formData, "region"),
+      participationMode: readStringFormValue(formData, "participationMode"),
+    }
+
+    const query = createFilterQuery(nextFilters)
+    const isSameFilters = query === currentQuery
+
+    if (isSameFilters) return
+
+    setSearchingQuery(query)
+    router.push(query ? `/recommendations?${query}` : "/recommendations")
+  }
+
   return (
     <form
+      aria-label="おすすめ案件フィルター"
       method="get"
+      onSubmit={handleSubmit}
       className="mb-6 grid gap-4 rounded-[10px] border border-card-border bg-white p-4 shadow-sm sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1fr_auto] lg:items-end"
     >
       <div className="flex flex-col gap-1">
@@ -127,14 +183,20 @@ export function RecommendationFilters({ filters }: RecommendationFiltersProps) {
       <div className="flex gap-2 sm:col-span-2 lg:col-span-1">
         <button
           type="submit"
-          className="flex h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark sm:flex-none"
+          disabled={isSearching}
+          className="flex h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark disabled:cursor-wait disabled:opacity-80 sm:flex-none"
         >
-          <Search className="size-4" />
-          絞り込む
+          {isSearching ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Search className="size-4" />
+          )}
+          {isSearching ? "検索中" : "絞り込む"}
         </button>
         <Link
           href="/recommendations"
-          className="flex h-11 items-center justify-center gap-2 rounded-lg border border-card-border px-4 text-sm font-medium text-text-body hover:bg-background"
+          aria-disabled={isSearching}
+          className="flex h-11 items-center justify-center gap-2 rounded-lg border border-card-border px-4 text-sm font-medium text-text-body hover:bg-background aria-disabled:pointer-events-none aria-disabled:opacity-60"
         >
           <X className="size-4" />
           クリア

--- a/app/src/app/recommendations/page.tsx
+++ b/app/src/app/recommendations/page.tsx
@@ -12,6 +12,7 @@ type RecommendationsPageProps = {
   searchParams?: Promise<{
     category?: string | string[]
     region?: string | string[]
+    participationMode?: string | string[]
   }>
 }
 
@@ -19,6 +20,13 @@ function pickSearchParam(value?: string | string[]): string | undefined {
   const param = Array.isArray(value) ? value[0] : value
   const trimmed = param?.trim()
   return trimmed ? trimmed : undefined
+}
+
+function pickParticipationMode(
+  value?: string | string[]
+): RecommendationFilters["participationMode"] | undefined {
+  const param = pickSearchParam(value)
+  return param === "online" || param === "offline" ? param : undefined
 }
 
 /**
@@ -35,8 +43,11 @@ export default async function RecommendationsPage({
   const filters: RecommendationFilters = {
     category: pickSearchParam(params?.category),
     region: pickSearchParam(params?.region),
+    participationMode: pickParticipationMode(params?.participationMode),
   }
-  const hasActiveFilters = Boolean(filters.category || filters.region)
+  const hasActiveFilters = Boolean(
+    filters.category || filters.region || filters.participationMode
+  )
 
   // 認証チェック
   let user = null

--- a/app/src/app/recommendations/page.tsx
+++ b/app/src/app/recommendations/page.tsx
@@ -3,8 +3,23 @@ import Link from "next/link"
 import { Brain, Sparkles } from "lucide-react"
 import { createClient } from "@/lib/supabase/server"
 import { fetchRecommendations } from "@/lib/recommendations/actions"
+import type { RecommendationFilters } from "@/lib/recommendations/types"
 import { Header } from "@/app/components/Header"
 import { OpportunityCard } from "./components/OpportunityCard"
+import { RecommendationFilters as RecommendationFiltersForm } from "./components/RecommendationFilters"
+
+type RecommendationsPageProps = {
+  searchParams?: Promise<{
+    category?: string | string[]
+    region?: string | string[]
+  }>
+}
+
+function pickSearchParam(value?: string | string[]): string | undefined {
+  const param = Array.isArray(value) ? value[0] : value
+  const trimmed = param?.trim()
+  return trimmed ? trimmed : undefined
+}
 
 /**
  * おすすめ案件一覧ページ
@@ -13,7 +28,16 @@ import { OpportunityCard } from "./components/OpportunityCard"
  * - ログイン済み（未ログイン → /login へリダイレクト）
  * - 診断済み（未診断 → 診断を促すメッセージを表示）
  */
-export default async function RecommendationsPage() {
+export default async function RecommendationsPage({
+  searchParams,
+}: RecommendationsPageProps) {
+  const params = await searchParams
+  const filters: RecommendationFilters = {
+    category: pickSearchParam(params?.category),
+    region: pickSearchParam(params?.region),
+  }
+  const hasActiveFilters = Boolean(filters.category || filters.region)
+
   // 認証チェック
   let user = null
   try {
@@ -30,7 +54,7 @@ export default async function RecommendationsPage() {
   }
 
   const { recommendations, hasCompletedDiagnosis } =
-    await fetchRecommendations()
+    await fetchRecommendations(filters)
 
   return (
     <div className="min-h-screen bg-background font-sans">
@@ -44,6 +68,10 @@ export default async function RecommendationsPage() {
             あなたの性格特性に合ったボランティア活動をご提案します
           </p>
         </div>
+
+        {hasCompletedDiagnosis && (
+          <RecommendationFiltersForm filters={filters} />
+        )}
 
         {/* 診断未実施の場合 */}
         {!hasCompletedDiagnosis && (
@@ -73,7 +101,9 @@ export default async function RecommendationsPage() {
         {hasCompletedDiagnosis && recommendations.length === 0 && (
           <div className="flex flex-col items-center gap-4 rounded-[10px] border border-card-border bg-white px-8 py-12 text-center shadow-sm">
             <p className="text-base text-text-body">
-              現在公開中の案件はありません。しばらくしてから再度ご確認ください。
+              {hasActiveFilters
+                ? "条件に一致する案件はありません。カテゴリや地域を変更して再度お試しください。"
+                : "現在公開中の案件はありません。しばらくしてから再度ご確認ください。"}
             </p>
           </div>
         )}

--- a/app/src/lib/recommendations/actions.test.ts
+++ b/app/src/lib/recommendations/actions.test.ts
@@ -179,6 +179,81 @@ describe("fetchRecommendations", () => {
     ])
   })
 
+  it("participationMode が online の場合、オンラインまたはリモートの案件だけを返す", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({
+        id: "online-location",
+        location: "オンライン",
+        organization: {
+          organizationName: "オンライン団体",
+          activityCategories: ["IT支援"],
+          activityAreas: ["全国"],
+        },
+      }),
+      createOpportunity({
+        id: "remote-area",
+        location: "東京都渋谷区",
+        organization: {
+          organizationName: "リモート団体",
+          activityCategories: ["IT支援"],
+          activityAreas: ["リモート"],
+        },
+      }),
+      createOpportunity({
+        id: "offline",
+        location: "東京都練馬区",
+        organization: {
+          organizationName: "対面団体",
+          activityCategories: ["地域活動"],
+          activityAreas: ["練馬区"],
+        },
+      }),
+    ])
+
+    const result = await fetchRecommendations({ participationMode: "online" })
+
+    expect(result.recommendations.map((item) => item.id)).toEqual([
+      "online-location",
+      "remote-area",
+    ])
+  })
+
+  it("participationMode が offline の場合、オンラインまたはリモートを含まない案件だけを返す", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({
+        id: "online-location",
+        location: "オンライン",
+        organization: {
+          organizationName: "オンライン団体",
+          activityCategories: ["IT支援"],
+          activityAreas: ["全国"],
+        },
+      }),
+      createOpportunity({
+        id: "remote-area",
+        location: "東京都渋谷区",
+        organization: {
+          organizationName: "リモート団体",
+          activityCategories: ["IT支援"],
+          activityAreas: ["リモート"],
+        },
+      }),
+      createOpportunity({
+        id: "offline",
+        location: "東京都練馬区",
+        organization: {
+          organizationName: "対面団体",
+          activityCategories: ["地域活動"],
+          activityAreas: ["練馬区"],
+        },
+      }),
+    ])
+
+    const result = await fetchRecommendations({ participationMode: "offline" })
+
+    expect(result.recommendations.map((item) => item.id)).toEqual(["offline"])
+  })
+
   it("フィルタ後に該当案件がない場合、診断済みの空結果を返す", async () => {
     mockFindOpportunities.mockResolvedValue([
       createOpportunity({

--- a/app/src/lib/recommendations/actions.test.ts
+++ b/app/src/lib/recommendations/actions.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { BIG5Scores } from "@/lib/personality/types"
+
+const mockGetUser = vi.fn()
+const mockFindParticipant = vi.fn()
+const mockFindOpportunities = vi.fn()
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mockGetUser(),
+    },
+  }),
+}))
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    participantProfile: {
+      findUnique: (...args: unknown[]) => mockFindParticipant(...args),
+    },
+    opportunity: {
+      findMany: (...args: unknown[]) => mockFindOpportunities(...args),
+    },
+  },
+}))
+
+const { fetchRecommendations } = await import("./actions")
+
+const diagnosisScores: BIG5Scores = {
+  extraversion: 50,
+  agreeableness: 50,
+  conscientiousness: 50,
+  neuroticism: 50,
+  openness: 50,
+}
+
+type MockOpportunity = {
+  id: string
+  title: string
+  description: string | null
+  requirementTraits: Record<string, number> | null
+  location: string | null
+  organization: {
+    organizationName: string
+    activityCategories: string[] | null
+    activityAreas: string[] | null
+  }
+}
+
+function createOpportunity({
+  id,
+  ...overrides
+}: Partial<MockOpportunity> & { id: string }): MockOpportunity {
+  return {
+    id,
+    title: `${id} の案件`,
+    description: null,
+    requirementTraits: { extraversion: 50 },
+    location: "東京都渋谷区",
+    organization: {
+      organizationName: `${id} 団体`,
+      activityCategories: ["環境保全"],
+      activityAreas: ["渋谷区"],
+    },
+    ...overrides,
+  }
+}
+
+describe("fetchRecommendations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } } })
+    mockFindParticipant.mockResolvedValue({ diagnosisScores })
+  })
+
+  it("category が指定された場合、団体の活動カテゴリに一致する案件だけを返す", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({
+        id: "env-1",
+        organization: {
+          organizationName: "環境団体",
+          activityCategories: ["環境保全", "地域活動"],
+          activityAreas: ["渋谷区"],
+        },
+      }),
+      createOpportunity({
+        id: "edu-1",
+        organization: {
+          organizationName: "教育団体",
+          activityCategories: ["教育"],
+          activityAreas: ["渋谷区"],
+        },
+      }),
+    ])
+
+    const result = await fetchRecommendations({ category: "環境保全" })
+
+    expect(result.hasCompletedDiagnosis).toBe(true)
+    expect(result.recommendations.map((item) => item.id)).toEqual(["env-1"])
+  })
+
+  it("region が指定された場合、案件場所または団体活動地域に一致する案件をスコア降順で返す", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({
+        id: "area-match",
+        requirementTraits: { extraversion: 70 },
+        location: "神奈川県横浜市",
+        organization: {
+          organizationName: "地域団体",
+          activityCategories: ["地域活動"],
+          activityAreas: ["東京都渋谷区"],
+        },
+      }),
+      createOpportunity({
+        id: "location-match",
+        requirementTraits: { extraversion: 50 },
+        location: "東京都渋谷区",
+        organization: {
+          organizationName: "場所一致団体",
+          activityCategories: ["地域活動"],
+          activityAreas: ["世田谷区"],
+        },
+      }),
+      createOpportunity({
+        id: "no-match",
+        location: "大阪府大阪市",
+        organization: {
+          organizationName: "対象外団体",
+          activityCategories: ["地域活動"],
+          activityAreas: ["大阪府"],
+        },
+      }),
+    ])
+
+    const result = await fetchRecommendations({ region: "渋谷区" })
+
+    expect(result.recommendations.map((item) => item.id)).toEqual([
+      "location-match",
+      "area-match",
+    ])
+  })
+
+  it("category と region が指定された場合、両方に一致する案件だけを返す", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({
+        id: "both-match",
+        organization: {
+          organizationName: "両方一致団体",
+          activityCategories: ["環境保全"],
+          activityAreas: ["渋谷区"],
+        },
+      }),
+      createOpportunity({
+        id: "category-only",
+        location: "大阪府大阪市",
+        organization: {
+          organizationName: "カテゴリのみ団体",
+          activityCategories: ["環境保全"],
+          activityAreas: ["大阪府"],
+        },
+      }),
+      createOpportunity({
+        id: "region-only",
+        organization: {
+          organizationName: "地域のみ団体",
+          activityCategories: ["教育"],
+          activityAreas: ["渋谷区"],
+        },
+      }),
+    ])
+
+    const result = await fetchRecommendations({
+      category: "環境保全",
+      region: "渋谷区",
+    })
+
+    expect(result.recommendations.map((item) => item.id)).toEqual([
+      "both-match",
+    ])
+  })
+
+  it("フィルタ後に該当案件がない場合、診断済みの空結果を返す", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({
+        id: "edu-1",
+        organization: {
+          organizationName: "教育団体",
+          activityCategories: ["教育"],
+          activityAreas: ["渋谷区"],
+        },
+      }),
+    ])
+
+    const result = await fetchRecommendations({ category: "環境保全" })
+
+    expect(result).toEqual({
+      recommendations: [],
+      hasCompletedDiagnosis: true,
+    })
+  })
+})

--- a/app/src/lib/recommendations/actions.ts
+++ b/app/src/lib/recommendations/actions.ts
@@ -18,6 +18,8 @@ const BIG5_TRAIT_KEYS = [
   "openness",
 ] as const
 
+const ONLINE_KEYWORDS = ["オンライン", "リモート"] as const
+
 /**
  * 未知の値が BIG5Scores 型かどうかを実行時に検証するタイプガード
  */
@@ -68,6 +70,34 @@ function matchesRegion(
   return locationMatched || areaMatched
 }
 
+function normalizeParticipationMode(
+  value?: string
+): RecommendationFilters["participationMode"] | null {
+  return value === "online" || value === "offline" ? value : null
+}
+
+function isOnlineOpportunity(
+  location: string | null,
+  activityAreas: unknown
+): boolean {
+  const values = [
+    ...(location ? [location] : []),
+    ...toStringArray(activityAreas),
+  ]
+  return values.some((value) =>
+    ONLINE_KEYWORDS.some((keyword) => value.includes(keyword))
+  )
+}
+
+function matchesParticipationMode(
+  location: string | null,
+  activityAreas: unknown,
+  participationMode: NonNullable<RecommendationFilters["participationMode"]>
+): boolean {
+  const online = isOnlineOpportunity(location, activityAreas)
+  return participationMode === "online" ? online : !online
+}
+
 /**
  * 現在のログインユーザーのBIG5診断スコアをもとに、
  * マッチングスコア順にソートされたおすすめ案件一覧を返す。
@@ -103,6 +133,9 @@ export async function fetchRecommendations(
 
     const categoryFilter = normalizeFilterValue(filters?.category)
     const regionFilter = normalizeFilterValue(filters?.region)
+    const participationModeFilter = normalizeParticipationMode(
+      filters?.participationMode
+    )
 
     // 公開中の案件を団体名とともに取得
     const opportunities = await prisma.opportunity.findMany({
@@ -141,6 +174,17 @@ export async function fetchRecommendations(
           opp.location,
           opp.organization.activityAreas,
           regionFilter
+        )
+      ) {
+        return false
+      }
+
+      if (
+        participationModeFilter &&
+        !matchesParticipationMode(
+          opp.location,
+          opp.organization.activityAreas,
+          participationModeFilter
         )
       ) {
         return false

--- a/app/src/lib/recommendations/actions.ts
+++ b/app/src/lib/recommendations/actions.ts
@@ -3,7 +3,11 @@
 import { createClient } from "@/lib/supabase/server"
 import { prisma } from "@/lib/prisma"
 import type { BIG5Scores } from "@/lib/personality/types"
-import type { OpportunityRecommendation, RecommendationResult } from "./types"
+import type {
+  OpportunityRecommendation,
+  RecommendationFilters,
+  RecommendationResult,
+} from "./types"
 import { calculateMatchScore } from "./matching"
 
 const BIG5_TRAIT_KEYS = [
@@ -38,6 +42,32 @@ function toPartialBIG5Scores(
   return result
 }
 
+function normalizeFilterValue(value?: string): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+function matchesCategory(value: unknown, category: string): boolean {
+  return toStringArray(value).some((item) => item === category)
+}
+
+function matchesRegion(
+  location: string | null,
+  activityAreas: unknown,
+  region: string
+): boolean {
+  const locationMatched = location?.includes(region) ?? false
+  const areaMatched = toStringArray(activityAreas).some((area) =>
+    area.includes(region)
+  )
+  return locationMatched || areaMatched
+}
+
 /**
  * 現在のログインユーザーのBIG5診断スコアをもとに、
  * マッチングスコア順にソートされたおすすめ案件一覧を返す。
@@ -46,7 +76,9 @@ function toPartialBIG5Scores(
  * - 診断未実施時: recommendations=[], hasCompletedDiagnosis=false
  * - 正常時: マッチングスコア降順の案件一覧
  */
-export async function fetchRecommendations(): Promise<RecommendationResult> {
+export async function fetchRecommendations(
+  filters?: RecommendationFilters
+): Promise<RecommendationResult> {
   try {
     const supabase = await createClient()
 
@@ -69,6 +101,9 @@ export async function fetchRecommendations(): Promise<RecommendationResult> {
       return { recommendations: [], hasCompletedDiagnosis: false }
     }
 
+    const categoryFilter = normalizeFilterValue(filters?.category)
+    const regionFilter = normalizeFilterValue(filters?.region)
+
     // 公開中の案件を団体名とともに取得
     const opportunities = await prisma.opportunity.findMany({
       where: { status: "published" },
@@ -76,9 +111,14 @@ export async function fetchRecommendations(): Promise<RecommendationResult> {
         id: true,
         title: true,
         description: true,
+        location: true,
         requirementTraits: true,
         organization: {
-          select: { organizationName: true },
+          select: {
+            organizationName: true,
+            activityCategories: true,
+            activityAreas: true,
+          },
         },
       },
     })
@@ -87,8 +127,34 @@ export async function fetchRecommendations(): Promise<RecommendationResult> {
       return { recommendations: [], hasCompletedDiagnosis: true }
     }
 
+    const filteredOpportunities = opportunities.filter((opp) => {
+      if (
+        categoryFilter &&
+        !matchesCategory(opp.organization.activityCategories, categoryFilter)
+      ) {
+        return false
+      }
+
+      if (
+        regionFilter &&
+        !matchesRegion(
+          opp.location,
+          opp.organization.activityAreas,
+          regionFilter
+        )
+      ) {
+        return false
+      }
+
+      return true
+    })
+
+    if (filteredOpportunities.length === 0) {
+      return { recommendations: [], hasCompletedDiagnosis: true }
+    }
+
     // マッチングスコアを計算してソート
-    const recommendations: OpportunityRecommendation[] = opportunities
+    const recommendations: OpportunityRecommendation[] = filteredOpportunities
       .map((opp) => ({
         id: opp.id,
         title: opp.title,

--- a/app/src/lib/recommendations/types.ts
+++ b/app/src/lib/recommendations/types.ts
@@ -15,6 +15,13 @@ export interface OpportunityRecommendation {
   matchScore: number
 }
 
+export interface RecommendationFilters {
+  /** 団体の活動カテゴリ */
+  category?: string
+  /** 案件場所または団体の活動地域 */
+  region?: string
+}
+
 export interface RecommendationResult {
   /** マッチングスコア順の案件一覧 */
   recommendations: OpportunityRecommendation[]

--- a/app/src/lib/recommendations/types.ts
+++ b/app/src/lib/recommendations/types.ts
@@ -20,6 +20,8 @@ export interface RecommendationFilters {
   category?: string
   /** 案件場所または団体の活動地域 */
   region?: string
+  /** 参加形態 */
+  participationMode?: "online" | "offline"
 }
 
 export interface RecommendationResult {


### PR DESCRIPTION
## Summary
- おすすめ案件一覧にカテゴリ・地域フィルタを追加し、GET パラメータで絞り込みできるようにしました。
- フィルタ条件に応じて、団体の活動カテゴリ・活動地域、案件の所在地をもとに候補を絞り込むようにしました。
- サインアップ完了画面をクライアント依存の遷移から `Link` に置き換え、共通キーを `constants.ts` に分離しました。
- 日本語フォントの適用方法を整理し、`layout` から `next/font/google` 依存を外しました。
- `Makefile` の type-check を本番環境相当の `NODE_ENV=production` で実行するように変更しました。

## Testing
- `fetchRecommendations` のカテゴリ・地域フィルタ、空結果、組み合わせ条件をカバーする単体テストを追加しました。
- サインアップ完了画面とプロフィール入力画面の参照先変更を反映しました。
- Not run (not requested)