### PR TITLE
fix: OAuth後のユーザーレコード同期を保証

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -111,7 +111,21 @@ make supabase-start
 
 `Unsupported provider: provider is not enabled` が出る場合は、`.env.local` の Google OAuth 環境変数を設定したうえで Supabase を再起動してください。
 
-### 4. テーブル・データの確認
+### 4. Supabase Auth → m_user 同期
+
+Volunty では OAuth callback、ロール選択、プロフィール登録時にアプリ側で `m_user` を `upsert` します。そのため、Supabase Auth トリガーが未適用でも基本のオンボーディングフローは動作します。
+
+補助的な同期経路として、本番・ローカルともに Prisma migration 適用後、`app/prisma/supabase-auth-trigger.sql` を Supabase SQL Editor または `psql` で適用してください。
+
+```bash
+# リポジトリルートから実行する場合
+psql "$DIRECT_URL" -f app/prisma/supabase-auth-trigger.sql
+
+# app/ ディレクトリから実行する場合
+psql "$DIRECT_URL" -f prisma/supabase-auth-trigger.sql
+```
+
+### 5. テーブル・データの確認
 
 **Supabase Studio（GUI）**
 

--- a/app/prisma/supabase-auth-trigger.sql
+++ b/app/prisma/supabase-auth-trigger.sql
@@ -15,11 +15,23 @@ BEGIN
   VALUES (
     NEW.id,
     NEW.email,
-    COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.raw_user_meta_data->>'name'),
-    NEW.raw_user_meta_data->>'avatar_url',
+    COALESCE(
+      NEW.raw_user_meta_data->>'full_name',
+      NEW.raw_user_meta_data->>'name',
+      NEW.raw_user_meta_data->>'display_name'
+    ),
+    COALESCE(
+      NEW.raw_user_meta_data->>'avatar_url',
+      NEW.raw_user_meta_data->>'picture'
+    ),
     NOW(),
     NOW()
-  );
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    email = EXCLUDED.email,
+    name = COALESCE(EXCLUDED.name, public.m_user.name),
+    avatar_url = COALESCE(EXCLUDED.avatar_url, public.m_user.avatar_url),
+    updated_at = NOW();
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/app/src/app/auth/callback/route.test.ts
+++ b/app/src/app/auth/callback/route.test.ts
@@ -4,19 +4,38 @@ import { GET } from "./route";
 
 const mocks = vi.hoisted(() => ({
   exchangeCodeForSession: vi.fn(),
+  getUser: vi.fn(),
+  ensureUserRecord: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: () => ({
     auth: {
       exchangeCodeForSession: mocks.exchangeCodeForSession,
+      getUser: mocks.getUser,
     },
   }),
 }));
 
+vi.mock("@/lib/auth/ensure-user-record", () => ({
+  ensureUserRecord: mocks.ensureUserRecord,
+}));
+
 describe("auth callback route", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: "user-123",
+          email: "user@example.com",
+          user_metadata: { full_name: "山田 太郎" },
+        },
+      },
+      error: null,
+    });
+    mocks.ensureUserRecord.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -33,6 +52,12 @@ describe("auth callback route", () => {
     );
 
     expect(mocks.exchangeCodeForSession).toHaveBeenCalledWith("ok");
+    expect(mocks.getUser).toHaveBeenCalled();
+    expect(mocks.ensureUserRecord).toHaveBeenCalledWith({
+      id: "user-123",
+      email: "user@example.com",
+      user_metadata: { full_name: "山田 太郎" },
+    });
     expect(response.headers.get("location")).toBe(
       "http://localhost:3000/mypage?tab=profile&toast=login-success"
     );
@@ -49,6 +74,40 @@ describe("auth callback route", () => {
 
     expect(response.headers.get("location")).toBe(
       "http://localhost:3000/login?error=auth"
+    );
+    expect(mocks.getUser).not.toHaveBeenCalled();
+    expect(mocks.ensureUserRecord).not.toHaveBeenCalled();
+  });
+
+  it("ユーザー取得に失敗した場合は user-sync エラーでログイン画面へ戻す", async () => {
+    mocks.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+    mocks.getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: "user not found" },
+    });
+
+    const response = await GET(
+      new Request("http://0.0.0.0:3000/auth/callback?code=ok")
+    );
+
+    expect(mocks.ensureUserRecord).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/login?error=user-sync"
+    );
+  });
+
+  it("m_user 同期に失敗した場合は user-sync エラーでログイン画面へ戻す", async () => {
+    mocks.exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+    mocks.ensureUserRecord.mockRejectedValueOnce(new Error("DB error"));
+
+    const response = await GET(
+      new Request("http://0.0.0.0:3000/auth/callback?code=ok")
+    );
+
+    expect(mocks.getUser).toHaveBeenCalled();
+    expect(mocks.ensureUserRecord).toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/login?error=user-sync"
     );
   });
 

--- a/app/src/app/auth/callback/route.ts
+++ b/app/src/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { ensureUserRecord } from "@/lib/auth/ensure-user-record";
 import { createClient } from "@/lib/supabase/server";
 
 function normalizeOrigin(origin: string) {
@@ -19,9 +20,9 @@ function buildLoginSuccessUrl(origin: string, next: string | null) {
   return redirectUrl.toString();
 }
 
-function buildLoginErrorUrl(origin: string) {
+function buildLoginErrorUrl(origin: string, reason = "auth") {
   const redirectUrl = new URL("/login", origin);
-  redirectUrl.searchParams.set("error", "auth");
+  redirectUrl.searchParams.set("error", reason);
   return redirectUrl.toString();
 }
 
@@ -45,6 +46,23 @@ export async function GET(request: Request) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
+      const {
+        data: { user },
+        error: getUserError,
+      } = await supabase.auth.getUser();
+
+      if (getUserError || !user) {
+        console.error("[AuthCallback] ユーザー取得エラー:", getUserError);
+        return NextResponse.redirect(buildLoginErrorUrl(origin, "user-sync"));
+      }
+
+      try {
+        await ensureUserRecord(user);
+      } catch (err) {
+        console.error("[AuthCallback] m_user同期エラー:", err);
+        return NextResponse.redirect(buildLoginErrorUrl(origin, "user-sync"));
+      }
+
       return NextResponse.redirect(buildLoginSuccessUrl(origin, next));
     }
 

--- a/app/src/lib/auth/ensure-user-record.test.ts
+++ b/app/src/lib/auth/ensure-user-record.test.ts
@@ -1,0 +1,142 @@
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrismaUserUpsert = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      upsert: (...args: unknown[]) => mockPrismaUserUpsert(...args),
+    },
+  },
+}));
+
+const { ensureUserRecord } = await import("./ensure-user-record");
+
+function createSupabaseUser(
+  user: Partial<SupabaseUser> & Pick<SupabaseUser, "id">
+): SupabaseUser {
+  return {
+    app_metadata: {},
+    aud: "authenticated",
+    created_at: "2026-06-15T00:00:00.000Z",
+    email: undefined,
+    user_metadata: {},
+    ...user,
+  } as SupabaseUser;
+}
+
+describe("ensureUserRecord", () => {
+  const now = new Date("2026-06-15T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.clearAllMocks();
+    mockPrismaUserUpsert.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("Supabase Auth ユーザーから m_user を upsert する", async () => {
+    const user = createSupabaseUser({
+      id: "user-123",
+      email: "user@example.com",
+      user_metadata: {
+        full_name: "山田 太郎",
+        avatar_url: "https://example.com/avatar.png",
+      },
+    });
+
+    await ensureUserRecord(user);
+
+    expect(mockPrismaUserUpsert).toHaveBeenCalledWith({
+      where: { id: "user-123" },
+      update: {
+        email: "user@example.com",
+        name: "山田 太郎",
+        avatarUrl: "https://example.com/avatar.png",
+        lastLoginAt: now,
+      },
+      create: {
+        id: "user-123",
+        email: "user@example.com",
+        name: "山田 太郎",
+        avatarUrl: "https://example.com/avatar.png",
+        lastLoginAt: now,
+      },
+    });
+  });
+
+  it("metadata が不足している場合は既存の name / avatarUrl を null で上書きしない", async () => {
+    const user = createSupabaseUser({
+      id: "user-456",
+      email: null,
+      user_metadata: {},
+    });
+
+    await ensureUserRecord(user);
+
+    expect(mockPrismaUserUpsert).toHaveBeenCalledWith({
+      where: { id: "user-456" },
+      update: {
+        email: null,
+        lastLoginAt: now,
+      },
+      create: {
+        id: "user-456",
+        email: null,
+        name: null,
+        avatarUrl: null,
+        lastLoginAt: now,
+      },
+    });
+  });
+
+  it("role 指定時も updateRole が true でなければ既存ユーザーの role を変更しない", async () => {
+    const user = createSupabaseUser({
+      id: "user-789",
+      email: "role@example.com",
+      user_metadata: { display_name: "表示名", picture: "https://example.com/pic.png" },
+    });
+
+    await ensureUserRecord(user, { role: "organization" });
+
+    expect(mockPrismaUserUpsert).toHaveBeenCalledWith({
+      where: { id: "user-789" },
+      update: {
+        email: "role@example.com",
+        name: "表示名",
+        avatarUrl: "https://example.com/pic.png",
+        lastLoginAt: now,
+      },
+      create: {
+        id: "user-789",
+        email: "role@example.com",
+        name: "表示名",
+        avatarUrl: "https://example.com/pic.png",
+        lastLoginAt: now,
+        role: "organization",
+      },
+    });
+  });
+
+  it("updateRole が true の場合は既存ユーザーの role も同期する", async () => {
+    const user = createSupabaseUser({
+      id: "user-admin",
+      email: "admin@example.com",
+      user_metadata: { name: "管理者" },
+    });
+
+    await ensureUserRecord(user, { role: "admin", updateRole: true });
+
+    expect(mockPrismaUserUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ role: "admin" }),
+        create: expect.objectContaining({ role: "admin" }),
+      })
+    );
+  });
+});

--- a/app/src/lib/auth/ensure-user-record.ts
+++ b/app/src/lib/auth/ensure-user-record.ts
@@ -1,0 +1,55 @@
+import type { User as SupabaseUser } from "@supabase/supabase-js";
+import type { UserRole } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+type EnsureUserRecordOptions = {
+  role?: UserRole;
+  updateRole?: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringMetadata(
+  metadata: Record<string, unknown>,
+  keys: string[]
+): string | null {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export async function ensureUserRecord(
+  user: SupabaseUser,
+  options: EnsureUserRecordOptions = {}
+): Promise<void> {
+  const metadata = isRecord(user.user_metadata) ? user.user_metadata : {};
+  const name = readStringMetadata(metadata, ["full_name", "name", "display_name"]);
+  const avatarUrl = readStringMetadata(metadata, ["avatar_url", "picture"]);
+  const lastLoginAt = new Date();
+
+  await prisma.user.upsert({
+    where: { id: user.id },
+    update: {
+      email: user.email ?? null,
+      ...(name !== null ? { name } : {}),
+      ...(avatarUrl !== null ? { avatarUrl } : {}),
+      lastLoginAt,
+      ...(options.updateRole && options.role ? { role: options.role } : {}),
+    },
+    create: {
+      id: user.id,
+      email: user.email ?? null,
+      name,
+      avatarUrl,
+      lastLoginAt,
+      ...(options.role ? { role: options.role } : {}),
+    },
+  });
+}

--- a/app/src/lib/onboarding/actions.test.ts
+++ b/app/src/lib/onboarding/actions.test.ts
@@ -61,28 +61,68 @@ describe("selectRole", () => {
   });
 
   it("参加者ロール設定成功後、/onboarding/participant にリダイレクトする", async () => {
-    mockGetUser.mockReturnValue({ data: { user: { id: "user-123" } } });
+    mockGetUser.mockReturnValue({
+      data: {
+        user: {
+          id: "user-123",
+          email: "participant@example.com",
+          user_metadata: {
+            full_name: "参加 太郎",
+            avatar_url: "https://example.com/avatar.png",
+          },
+        },
+      },
+    });
     mockUpdateUser.mockReturnValue({ error: null });
-    mockPrismaUserUpdate.mockResolvedValue({});
 
     await expect(selectRole("participant")).rejects.toThrow("NEXT_REDIRECT");
 
     expect(mockUpdateUser).toHaveBeenCalledWith({ data: { role: "participant" } });
-    expect(mockPrismaUserUpdate).toHaveBeenCalledWith({
+    expect(mockPrismaUserUpsert).toHaveBeenCalledWith({
       where: { id: "user-123" },
-      data: { role: "participant" },
+      update: expect.objectContaining({
+        email: "participant@example.com",
+        name: "参加 太郎",
+        avatarUrl: "https://example.com/avatar.png",
+        lastLoginAt: expect.any(Date),
+        role: "participant",
+      }),
+      create: expect.objectContaining({
+        id: "user-123",
+        email: "participant@example.com",
+        name: "参加 太郎",
+        avatarUrl: "https://example.com/avatar.png",
+        lastLoginAt: expect.any(Date),
+        role: "participant",
+      }),
     });
     expect(mockRedirect).toHaveBeenCalledWith("/onboarding/participant");
   });
 
   it("団体ロール設定成功後、/onboarding/organization にリダイレクトする", async () => {
-    mockGetUser.mockReturnValue({ data: { user: { id: "user-456" } } });
+    mockGetUser.mockReturnValue({
+      data: {
+        user: {
+          id: "user-456",
+          email: "organization@example.com",
+          user_metadata: {
+            name: "団体 花子",
+          },
+        },
+      },
+    });
     mockUpdateUser.mockReturnValue({ error: null });
-    mockPrismaUserUpdate.mockResolvedValue({});
 
     await expect(selectRole("organization")).rejects.toThrow("NEXT_REDIRECT");
 
     expect(mockUpdateUser).toHaveBeenCalledWith({ data: { role: "organization" } });
+    expect(mockPrismaUserUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-456" },
+        update: expect.objectContaining({ role: "organization" }),
+        create: expect.objectContaining({ role: "organization" }),
+      })
+    );
     expect(mockRedirect).toHaveBeenCalledWith("/onboarding/organization");
   });
 
@@ -93,6 +133,7 @@ describe("selectRole", () => {
     await expect(selectRole("participant")).rejects.toThrow(
       "ロール更新に失敗しました: Auth error"
     );
+    expect(mockPrismaUserUpsert).not.toHaveBeenCalled();
     expect(mockRedirect).not.toHaveBeenCalled();
   });
 });

--- a/app/src/lib/onboarding/actions.ts
+++ b/app/src/lib/onboarding/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { ensureUserRecord } from "@/lib/auth/ensure-user-record";
 import { createClient } from "@/lib/supabase/server";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
@@ -27,38 +28,14 @@ export async function selectRole(role: "participant" | "organization") {
   });
   if (authError) throw new Error(`ロール更新に失敗しました: ${authError.message}`);
 
-  // DB のロールも同期
-  await prisma.user.update({
-    where: { id: user.id },
-    data: { role },
-  });
+  // DB のロールも同期し、m_user 未作成環境でも進めるようにする
+  await ensureUserRecord(user, { role, updateRole: true });
 
   redirect(
     role === "organization"
       ? "/onboarding/organization"
       : "/onboarding/participant"
   );
-}
-
-/**
- * m_user レコードが存在しなければ作成する（Supabaseトリガー未動作時のセーフガード）
- */
-async function ensureUserExists(
-  userId: string,
-  email: string | undefined,
-  name: string | undefined,
-  role: "participant" | "organization"
-) {
-  await prisma.user.upsert({
-    where: { id: userId },
-    update: {},
-    create: {
-      id: userId,
-      email: email ?? null,
-      name: name ?? null,
-      role,
-    },
-  });
 }
 
 /**
@@ -101,8 +78,8 @@ export async function registerParticipant(
       return { success: false, error: "都道府県は必須です" };
     }
 
-    // m_user がなければ作成（トリガー未動作時のセーフガード）
-    await ensureUserExists(user.id, user.email, data.name, "participant");
+    // m_user を保証し、ロールも参加者として同期する
+    await ensureUserRecord(user, { role: "participant", updateRole: true });
 
     await prisma.participantProfile.upsert({
       where: { userId: user.id },
@@ -207,8 +184,8 @@ export async function registerOrganization(
         ? data.activityCategories
         : undefined;
 
-    // m_user がなければ作成（トリガー未動作時のセーフガード）
-    await ensureUserExists(user.id, user.email, data.representativeName, "organization");
+    // m_user を保証し、ロールも団体として同期する
+    await ensureUserRecord(user, { role: "organization", updateRole: true });
 
     // 団体プロフィールを作成（既存の場合は更新）
     await prisma.organizationProfile.upsert({


### PR DESCRIPTION
## 概要

Issue #97 の対応として、OAuth callback 後にアプリ側でも `m_user` レコード作成を保証するようにしました。Supabase Auth trigger が未適用の環境でも、Googleログイン後にロール選択・オンボーディングへ進めることを目的にしています。

## 実装内容

- `ensureUserRecord()` を追加し、Supabase Auth の user から `m_user` を `prisma.user.upsert()` で同期
  - `id`, `email`, `name`, `avatarUrl`, `lastLoginAt` を同期
  - `name` は `full_name` / `name` / `display_name` から取得
  - `avatarUrl` は `avatar_url` / `picture` から取得
  - 既存ユーザーの `role` は `updateRole: true` の場合だけ更新
- `/auth/callback` で `exchangeCodeForSession()` 成功後に `getUser()` → `ensureUserRecord()` を実行
  - ユーザー取得失敗・DB同期失敗時は `/login?error=user-sync` にリダイレクト
- `selectRole()` を `prisma.user.update()` から共通 upsert 処理へ変更
  - `m_user` が未作成でもロール選択時に作成・同期できるように変更
- `registerParticipant()` / `registerOrganization()` の private な user 作成処理を共通 helper に統合
- `supabase-auth-trigger.sql` を `ON CONFLICT (id) DO UPDATE` 対応にして冪等化
- README に Supabase Auth → `m_user` 同期の説明と trigger SQL 適用手順を追記

## 検証

- `npx vitest run src/lib/auth/ensure-user-record.test.ts src/app/auth/callback/route.test.ts src/lib/onboarding/actions.test.ts`
  - 28 passed
- `npm run test`
  - 193 passed
- `npm run lint`
  - exit 0
  - 既存 warning 3件のみ
- `npm run build`
  - exit 0

## 関連 Issue

Closes #97
