### PR TITLE
[codex] 参加者オンボーディングのロール認可を追加

### DIFF
--- a/app/src/app/onboarding/participant/page.test.tsx
+++ b/app/src/app/onboarding/participant/page.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  getUser: vi.fn(),
+  userFindUnique: vi.fn(),
+  fetchParticipantProfileByUserId: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    mocks.redirect(url);
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mocks.getUser(),
+    },
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => mocks.userFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/participant-profile/server", () => ({
+  fetchParticipantProfileByUserId: (...args: unknown[]) =>
+    mocks.fetchParticipantProfileByUserId(...args),
+}));
+
+vi.mock("./components/ParticipantProfileForm", () => ({
+  ParticipantProfileForm: () => null,
+}));
+
+import OnboardingParticipantPage from "./page";
+
+describe("OnboardingParticipantPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUser.mockReturnValue({
+      data: {
+        user: {
+          id: "participant-user-123",
+          user_metadata: { role: "participant" },
+        },
+      },
+    });
+    mocks.userFindUnique.mockResolvedValue({ role: "participant" });
+    mocks.fetchParticipantProfileByUserId.mockResolvedValue(null);
+  });
+
+  it("participant ロールかつプロフィール未登録の場合、参加者フォームを表示する", async () => {
+    await expect(OnboardingParticipantPage()).resolves.toBeDefined();
+
+    expect(mocks.redirect).not.toHaveBeenCalled();
+    expect(mocks.userFindUnique).toHaveBeenCalledWith({
+      where: { id: "participant-user-123" },
+      select: { role: true },
+    });
+    expect(mocks.fetchParticipantProfileByUserId).toHaveBeenCalledWith(
+      "participant-user-123"
+    );
+  });
+
+  it("organization ロールの場合、団体オンボーディングへリダイレクトする", async () => {
+    mocks.getUser.mockReturnValue({
+      data: {
+        user: {
+          id: "organization-user-123",
+          user_metadata: { role: "participant" },
+        },
+      },
+    });
+    mocks.userFindUnique.mockResolvedValue({ role: "organization" });
+
+    await expect(OnboardingParticipantPage()).rejects.toThrow(
+      "NEXT_REDIRECT:/onboarding/organization"
+    );
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/onboarding/organization");
+    expect(mocks.fetchParticipantProfileByUserId).not.toHaveBeenCalled();
+  });
+
+  it("ロール未選択の場合、ロール選択画面へリダイレクトする", async () => {
+    mocks.getUser.mockReturnValue({
+      data: {
+        user: {
+          id: "no-role-user-123",
+          user_metadata: {},
+        },
+      },
+    });
+    mocks.userFindUnique.mockResolvedValue(null);
+
+    await expect(OnboardingParticipantPage()).rejects.toThrow(
+      "NEXT_REDIRECT:/onboarding/role"
+    );
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/onboarding/role");
+    expect(mocks.fetchParticipantProfileByUserId).not.toHaveBeenCalled();
+  });
+
+  it("participant ロールでプロフィール登録済みの場合、トップへリダイレクトする", async () => {
+    mocks.fetchParticipantProfileByUserId.mockResolvedValue({
+      id: "participant-profile-123",
+    });
+
+    await expect(OnboardingParticipantPage()).rejects.toThrow(
+      "NEXT_REDIRECT:/"
+    );
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+  });
+});

--- a/app/src/app/onboarding/participant/page.tsx
+++ b/app/src/app/onboarding/participant/page.tsx
@@ -1,11 +1,17 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
+import {
+  resolveOnboardingRole,
+  type OnboardingRole,
+} from "@/lib/onboarding/role";
 import { ParticipantProfileForm } from "./components/ParticipantProfileForm";
 import { fetchParticipantProfileByUserId } from "@/lib/participant-profile/server";
 
-/** 認証状態とプロフィール登録状況を取得する */
+/** 認証状態・ロール・プロフィール登録状況を取得する */
 async function getPageState(): Promise<{
   isAuthenticated: boolean;
+  role: OnboardingRole | null;
   hasProfile: boolean;
 }> {
   // 1. 認証チェック
@@ -15,28 +21,54 @@ async function getPageState(): Promise<{
     const { data } = await supabase.auth.getUser();
     user = data.user;
   } catch {
-    return { isAuthenticated: false, hasProfile: false };
+    return { isAuthenticated: false, role: null, hasProfile: false };
   }
 
   if (!user) {
-    return { isAuthenticated: false, hasProfile: false };
+    return { isAuthenticated: false, role: null, hasProfile: false };
+  }
+
+  const metadata = user.user_metadata as Record<string, unknown> | undefined;
+  let dbRole: unknown = null;
+
+  try {
+    const dbUser = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { role: true },
+    });
+    dbRole = dbUser?.role;
+  } catch (err) {
+    // DB エラー時は既存の Auth metadata にフォールバックする
+    console.error("[OnboardingParticipantPage] ロール確認に失敗:", err);
+  }
+
+  const role = resolveOnboardingRole({
+    dbRole,
+    metadataRole: metadata?.role,
+  });
+
+  if (role !== "participant") {
+    return { isAuthenticated: true, role, hasProfile: false };
   }
 
   // 2. プロフィールチェック（DB エラー時は未登録扱いだが認証は true を維持）
   try {
     const profile = await fetchParticipantProfileByUserId(user.id);
-    return { isAuthenticated: true, hasProfile: !!profile };
+    return { isAuthenticated: true, role, hasProfile: !!profile };
   } catch (err) {
     // DB エラーでもログイン状態は維持してフォームを表示する
     console.error("[OnboardingParticipantPage] プロフィール確認に失敗:", err);
-    return { isAuthenticated: true, hasProfile: false };
+    return { isAuthenticated: true, role, hasProfile: false };
   }
 }
 
 export default async function OnboardingParticipantPage() {
-  const { isAuthenticated, hasProfile } = await getPageState();
+  const { isAuthenticated, role, hasProfile } = await getPageState();
 
   if (!isAuthenticated) redirect("/login");
+  if (role === null) redirect("/onboarding/role");
+  if (role === "organization") redirect("/onboarding/organization");
+  if (role !== "participant") redirect("/");
   if (hasProfile) redirect("/");
 
   return <ParticipantProfileForm />;

--- a/app/src/lib/onboarding/actions.test.ts
+++ b/app/src/lib/onboarding/actions.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/supabase/server", () => ({
 // Prisma のモック
 const mockPrismaUserUpdate = vi.fn();
 const mockPrismaUserUpsert = vi.fn();
+const mockPrismaUserFindUnique = vi.fn();
 const mockPrismaOrgUpsert = vi.fn();
 const mockPrismaParticipantUpsert = vi.fn();
 vi.mock("@/lib/prisma", () => ({
@@ -33,6 +34,7 @@ vi.mock("@/lib/prisma", () => ({
     user: {
       update: (...args: unknown[]) => mockPrismaUserUpdate(...args),
       upsert: (...args: unknown[]) => mockPrismaUserUpsert(...args),
+      findUnique: (...args: unknown[]) => mockPrismaUserFindUnique(...args),
     },
     organizationProfile: {
       upsert: (...args: unknown[]) => mockPrismaOrgUpsert(...args),
@@ -101,6 +103,7 @@ describe("registerParticipant", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrismaUserUpsert.mockResolvedValue({});
+    mockPrismaUserFindUnique.mockResolvedValue({ role: "participant" });
   });
 
   it("未認証の場合、エラーを返す", async () => {
@@ -115,6 +118,64 @@ describe("registerParticipant", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("ログインが必要です");
     expect(mockPrismaParticipantUpsert).not.toHaveBeenCalled();
+  });
+
+  it("organization ロールの場合、参加者プロフィールを登録できない", async () => {
+    mockGetUser.mockReturnValue({
+      data: {
+        user: {
+          id: "org-user-123",
+          email: "org@example.com",
+          user_metadata: { role: "organization" },
+        },
+      },
+    });
+    mockPrismaUserFindUnique.mockResolvedValue({ role: "organization" });
+
+    const result = await registerParticipant({
+      name: "団体ユーザー",
+      birthday: "1990-01-15",
+      region: "東京都",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("参加者アカウントでログインしてください");
+    expect(mockPrismaUserFindUnique).toHaveBeenCalledWith({
+      where: { id: "org-user-123" },
+      select: { role: true },
+    });
+    expect(mockPrismaUserUpsert).not.toHaveBeenCalled();
+    expect(mockPrismaParticipantUpsert).not.toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+
+  it("ロール未選択の場合、参加者プロフィールを登録できない", async () => {
+    mockGetUser.mockReturnValue({
+      data: {
+        user: {
+          id: "no-role-user-123",
+          email: "user@example.com",
+          user_metadata: {},
+        },
+      },
+    });
+    mockPrismaUserFindUnique.mockResolvedValue(null);
+
+    const result = await registerParticipant({
+      name: "未選択ユーザー",
+      birthday: "1990-01-15",
+      region: "東京都",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("参加者ロールの選択が必要です");
+    expect(mockPrismaUserFindUnique).toHaveBeenCalledWith({
+      where: { id: "no-role-user-123" },
+      select: { role: true },
+    });
+    expect(mockPrismaUserUpsert).not.toHaveBeenCalled();
+    expect(mockPrismaParticipantUpsert).not.toHaveBeenCalled();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
   });
 
   it("nameが空の場合、バリデーションエラーを返す", async () => {
@@ -174,6 +235,10 @@ describe("registerParticipant", () => {
     });
 
     expect(result).toEqual({ success: true });
+    expect(mockPrismaUserFindUnique).toHaveBeenCalledWith({
+      where: { id: "user-123" },
+      select: { role: true },
+    });
 
     expect(mockPrismaParticipantUpsert).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/app/src/lib/onboarding/actions.ts
+++ b/app/src/lib/onboarding/actions.ts
@@ -4,6 +4,10 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/prisma/client";
+import {
+  getParticipantRoleError,
+  resolveOnboardingRole,
+} from "@/lib/onboarding/role";
 import type {
   RegisterParticipantData,
   RegisterParticipantResult,
@@ -79,6 +83,20 @@ export async function registerParticipant(
 
     if (!user) {
       return { success: false, error: "ログインが必要です" };
+    }
+
+    const dbUser = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { role: true },
+    });
+    const metadata = user.user_metadata as Record<string, unknown> | undefined;
+    const role = resolveOnboardingRole({
+      dbRole: dbUser?.role,
+      metadataRole: metadata?.role,
+    });
+
+    if (role !== "participant") {
+      return { success: false, error: getParticipantRoleError(role) };
     }
 
     // 必須フィールドのバリデーション

--- a/app/src/lib/onboarding/role.ts
+++ b/app/src/lib/onboarding/role.ts
@@ -1,0 +1,30 @@
+export type OnboardingRole = "participant" | "organization" | "admin";
+
+/** DB と Auth metadata の role 値を安全にオンボーディング用 role へ変換する */
+export function parseOnboardingRole(role: unknown): OnboardingRole | null {
+  if (role === "participant" || role === "organization" || role === "admin") {
+    return role;
+  }
+
+  return null;
+}
+
+/** DB の role を優先し、存在しない場合だけ Auth metadata の role を使う */
+export function resolveOnboardingRole({
+  dbRole,
+  metadataRole,
+}: {
+  dbRole: unknown;
+  metadataRole: unknown;
+}): OnboardingRole | null {
+  return parseOnboardingRole(dbRole) ?? parseOnboardingRole(metadataRole);
+}
+
+/** 参加者オンボーディング用の role 不一致エラー文言を返す */
+export function getParticipantRoleError(role: OnboardingRole | null): string {
+  if (role === null) {
+    return "参加者ロールの選択が必要です";
+  }
+
+  return "参加者アカウントでログインしてください";
+}


### PR DESCRIPTION
## 概要
- `/onboarding/participant` で DB の `m_user.role` を優先し、Auth metadata を fallback にした role 判定を追加しました。
- `organization` ロールは `/onboarding/organization`、role 未選択は `/onboarding/role`、その他の非 participant ロールは `/` へ redirect し、参加者フォームを表示しないようにしました。
- `registerParticipant()` の未認証チェック直後に role 認可を追加し、role 不一致時は `ensureUserExists()`、`participantProfile.upsert()`、`onboarding_completed` 更新を実行しないようにしました。
- role 解決 helper と、UI 直アクセス / server action 直接呼び出しを防御するテストを追加しました。

## 検証
- `npx vitest run src/lib/onboarding/actions.test.ts src/app/onboarding/participant/page.test.tsx`
- `npm test`（193 tests passed）
- `npm run lint`（0 errors、既存 warning 3 件）
- `npm run build`（exit 0。既存の baseline-browser-mapping 警告と `/diagnosis/result` の dynamic server usage ログあり）

Closes #98