### PR TITLE
[codex] 応募者詳細の診断タイプ参照を修正

### DIFF
--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -15,7 +15,6 @@ import type {
   Applicant,
   ApplicantsResult,
   UpdateApplicationStatusResult,
-  ApplicantDetail,
   ApplicantDetailResult,
 } from "./types";
 import { PERSONALITY_TYPES } from "@/lib/personality/constants";
@@ -668,11 +667,14 @@ export async function fetchApplicantDetail(
       );
     }
 
-    // PERSONALITY_TYPES から詳細を引き当て
+    // PERSONALITY_TYPES から詳細を引き当て（id 保存を優先し、既存の name 保存にも対応）
     const diagnosisType = participant?.diagnosis_type ?? null;
     const typeDetail = diagnosisType
-      ? PERSONALITY_TYPES.find((t) => t.name === diagnosisType) ?? null
+      ? PERSONALITY_TYPES.find((t) => t.id === diagnosisType) ??
+        PERSONALITY_TYPES.find((t) => t.name === diagnosisType) ??
+        null
       : null;
+    const diagnosisTypeLabel = typeDetail?.name ?? diagnosisType;
 
     return {
       data: {
@@ -681,7 +683,7 @@ export async function fetchApplicantDetail(
         message: (appData.message as string) ?? null,
         created_at: (appData.applied_at as string) ?? "",
         participant_name: participant?.name ?? "不明",
-        diagnosis_type: diagnosisType,
+        diagnosis_type: diagnosisTypeLabel,
         diagnosis_scores: participant?.diagnosis_scores ?? null,
         match_score: matchScore,
         opportunity_id: oppData.id as string,

--- a/app/src/lib/dashboard/applicant-detail.test.ts
+++ b/app/src/lib/dashboard/applicant-detail.test.ts
@@ -410,6 +410,76 @@ describe("fetchApplicantDetail", () => {
     ).toContain("イベント統括");
   });
 
+  it("診断タイプが id で保存されている場合も詳細を引き当てる", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    mockSingle
+      .mockReturnValueOnce({
+        data: {
+          id: "app-1",
+          status: "applied",
+          message: "応募メッセージです",
+          applied_at: "2026-01-20T00:00:00Z",
+          opportunity_id: "opp-1",
+          participant_id: "user-participant-1",
+          match_score: 91,
+        },
+        error: null,
+      })
+      .mockReturnValueOnce({
+        data: { id: "profile-123" },
+        error: null,
+      })
+      .mockReturnValueOnce({
+        data: {
+          id: "opp-1",
+          title: "子ども支援ボランティア",
+          requirement_traits: { agreeableness: 80 },
+        },
+        error: null,
+      })
+      .mockReturnValueOnce({
+        data: {
+          name: "テスト花子",
+          diagnosis_type: "supporter-care",
+          diagnosis_scores: {
+            extraversion: 65,
+            agreeableness: 85,
+            conscientiousness: 70,
+            neuroticism: 35,
+            openness: 60,
+          },
+        },
+        error: null,
+      });
+
+    const result: ApplicantDetailResult =
+      await fetchApplicantDetail("app-1");
+
+    expect(result.data).not.toBeNull();
+    expect(result.data!.participant_name).toBe("テスト花子");
+    expect(result.data!.diagnosis_type).toBe("サポーター・ケアタイプ");
+    expect(result.data!.diagnosis_scores).toEqual({
+      extraversion: 65,
+      agreeableness: 85,
+      conscientiousness: 70,
+      neuroticism: 35,
+      openness: 60,
+    });
+    expect(result.data!.match_score).toBe(91);
+    expect(result.data!.personality_type_detail).not.toBeNull();
+    expect(result.data!.personality_type_detail!.name).toBe(
+      "サポーター・ケアタイプ"
+    );
+    expect(result.data!.personality_type_detail!.description).toBe(
+      "他人の感情に敏感で、献身的にサポート"
+    );
+  });
+
   it("診断未実施の応募者でも正常に返す", async () => {
     const mockUser = { id: "org-123", email: "org@example.com" };
     mockGetUser.mockReturnValue({


### PR DESCRIPTION
## 実装概要
- `fetchApplicantDetail()` の personality type 引き当てを `id` 優先に変更しました。
- 既存データ互換のため、`id` で見つからない場合は従来どおり `name` でも fallback します。
- 応募者詳細の `diagnosis_type` は表示用の診断タイプ名を返すようにし、id 保存データでも画面上に日本語名が出るようにしました。
- `diagnosis_type` が `supporter-care` のような id で保存されているケースのユニットテストを追加しました。

## 確認したこと
- 診断結果保存処理では `profile.personalityType.id` / `profile.closestType.id` が `diagnosisType` に保存されることを確認しました。
- 既存テストには診断タイプ名で保存された前提も残っているため、name fallback を残して後方互換を維持しています。

## 検証
- `npx vitest run src/lib/dashboard/applicant-detail.test.ts`
- `npm run lint`（終了コード 0。未変更ファイルに既存 warning 2 件あり）
- `npm run test`（28 files / 194 tests passed）
- `npm run build`（終了コード 0）

Closes #100