### PR TITLE
MVP: 団体向けおすすめ参加者一覧・参加者詳細を実装する

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -161,6 +161,13 @@ export default async function DashboardPage() {
               団体プロフィールを編集
             </Link>
             <Link
+              href="/dashboard/participants"
+              className="inline-flex items-center gap-2 rounded-lg border border-card-border bg-white px-4 py-2 text-sm font-medium text-text-dark shadow-sm transition-colors hover:bg-primary/5"
+            >
+              <Users className="size-4" />
+              おすすめ参加者を見る
+            </Link>
+            <Link
               href="/dashboard/opportunities/new"
               className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-dark"
             >

--- a/app/src/app/dashboard/participants/[id]/page.tsx
+++ b/app/src/app/dashboard/participants/[id]/page.tsx
@@ -1,0 +1,277 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import {
+  ArrowLeft,
+  Brain,
+  MapPin,
+  MessageSquarePlus,
+  Sparkles,
+  Tag,
+  UserRound,
+} from "lucide-react";
+import { Header } from "@/app/components/Header";
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import { fetchRecommendedParticipantDetail } from "@/lib/dashboard/actions";
+import type { RecommendedParticipant } from "@/lib/dashboard/recommended-participants";
+
+export const dynamic = "force-dynamic";
+
+const BIG5_LABELS: Array<{
+  key: keyof RecommendedParticipant["diagnosisScores"];
+  label: string;
+}> = [
+  { key: "extraversion", label: "外向性" },
+  { key: "agreeableness", label: "協調性" },
+  { key: "conscientiousness", label: "誠実性" },
+  { key: "neuroticism", label: "神経症傾向" },
+  { key: "openness", label: "開放性" },
+];
+
+function formatList(values: string[], fallback: string): string {
+  return values.length > 0 ? values.join("、") : fallback;
+}
+
+function ScoreBar({ score }: { score: number }) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-text-body">
+          相性スコア
+        </span>
+        <span className="text-2xl font-bold text-text-dark">{score}%</span>
+      </div>
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-primary/15">
+        <div
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TraitBar({
+  label,
+  score,
+}: {
+  label: string;
+  score: number;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-sm font-medium text-text-body">{label}</span>
+        <span className="text-sm font-bold text-text-dark">{score}%</span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-primary/15">
+        <div
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EmptyPublishedOpportunityState() {
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <Link
+          href="/dashboard/participants"
+          className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          おすすめ参加者一覧に戻る
+        </Link>
+        <Card>
+          <CardHeader>
+            <h1 className="text-lg font-bold text-text-dark">
+              公開中の募集案件がありません
+            </h1>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm leading-6 text-text-body">
+              参加者との相性を計算するには、公開中の募集案件が必要です。
+            </p>
+            <Link
+              href="/dashboard/opportunities/new"
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark"
+            >
+              <Sparkles className="size-4" />
+              募集案件を作成
+            </Link>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}
+
+export default async function DashboardParticipantDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { participant, emptyReason, error } =
+    await fetchRecommendedParticipantDetail(id);
+
+  if (error === "ログインが必要です") {
+    redirect("/login");
+  }
+  if (error === "団体プロフィールが見つかりません") {
+    redirect("/onboarding/organization");
+  }
+  if (error === "承認済み団体のみ利用できます") {
+    redirect("/onboarding/pending");
+  }
+  if (emptyReason === "no_published_opportunities") {
+    return <EmptyPublishedOpportunityState />;
+  }
+  if (!participant) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <Link
+          href="/dashboard/participants"
+          className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          おすすめ参加者一覧に戻る
+        </Link>
+
+        <Card className="mb-6">
+          <CardContent>
+            <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
+                  <UserRound className="size-6 text-primary" />
+                </div>
+                <div>
+                  <h1 className="text-xl font-bold text-text-dark">
+                    {participant.name}
+                  </h1>
+                  <p className="mt-1 text-sm text-text-body">
+                    {participant.diagnosisTypeLabel ?? "診断タイプ未設定"}
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                disabled
+                className="inline-flex cursor-not-allowed items-center justify-center gap-2 rounded-lg border border-card-border bg-white px-4 py-2 text-sm font-medium text-text-body"
+              >
+                <MessageSquarePlus className="size-4" />
+                アプローチする（準備中）
+              </button>
+            </div>
+
+            {participant.bio && (
+              <p className="mt-5 whitespace-pre-wrap text-sm leading-6 text-text-body">
+                {participant.bio}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="mb-6">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-5 text-primary" />
+              <h2 className="text-lg font-bold text-text-dark">相性概要</h2>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-5 rounded-lg bg-background p-4">
+              <p className="mb-3 text-xs text-text-body">
+                最も相性が高い募集案件: {participant.bestOpportunityTitle}
+              </p>
+              <ScoreBar score={participant.matchScore} />
+            </div>
+
+            <h3 className="mb-2 text-sm font-bold text-text-dark">相性理由</h3>
+            <ul className="space-y-2">
+              {participant.matchReasons.map((reason) => (
+                <li
+                  key={reason}
+                  className="rounded-lg border border-card-border bg-white px-3 py-2 text-sm text-text-body"
+                >
+                  {reason}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <div className="mb-6 grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-bold text-text-dark">
+                プロフィール
+              </h2>
+            </CardHeader>
+            <CardContent>
+              <dl className="space-y-4 text-sm">
+                <div className="flex items-start gap-2">
+                  <MapPin className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <div>
+                    <dt className="font-medium text-text-dark">地域</dt>
+                    <dd className="mt-1 text-text-body">
+                      {participant.preferredLocation ?? participant.region}
+                    </dd>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Tag className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <div>
+                    <dt className="font-medium text-text-dark">
+                      興味カテゴリ
+                    </dt>
+                    <dd className="mt-1 text-text-body">
+                      {formatList(participant.interests, "未設定")}
+                    </dd>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Brain className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <div>
+                    <dt className="font-medium text-text-dark">参加可能形態</dt>
+                    <dd className="mt-1 text-text-body">
+                      {formatList(participant.availabilitySummary, "未設定")}
+                    </dd>
+                  </div>
+                </div>
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-bold text-text-dark">
+                BIG5 スコア
+              </h2>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {BIG5_LABELS.map(({ key, label }) => (
+                  <TraitBar
+                    key={key}
+                    label={label}
+                    score={participant.diagnosisScores[key]}
+                  />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/src/app/dashboard/participants/page.tsx
+++ b/app/src/app/dashboard/participants/page.tsx
@@ -1,0 +1,211 @@
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Brain,
+  ChevronRight,
+  MapPin,
+  SearchX,
+  Sparkles,
+  Tag,
+  UserRound,
+  Users,
+} from "lucide-react";
+import { redirect } from "next/navigation";
+import { Header } from "@/app/components/Header";
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import { fetchRecommendedParticipants } from "@/lib/dashboard/actions";
+import type { RecommendedParticipantsEmptyReason } from "@/lib/dashboard/types";
+import type { RecommendedParticipant } from "@/lib/dashboard/recommended-participants";
+
+export const dynamic = "force-dynamic";
+
+function formatList(values: string[], fallback: string): string {
+  return values.length > 0 ? values.join("、") : fallback;
+}
+
+function emptyStateMessage(reason?: RecommendedParticipantsEmptyReason): {
+  description: string;
+  title: string;
+} {
+  if (reason === "no_published_opportunities") {
+    return {
+      title: "公開中の募集案件がありません",
+      description:
+        "おすすめ参加者を表示するには、求める特性を設定した募集案件を公開してください。",
+    };
+  }
+
+  return {
+    title: "条件に合う参加者がまだいません",
+    description:
+      "公開プロフィールかつ診断済みの参加者が見つかると、相性スコア順に表示されます。",
+  };
+}
+
+function ScoreBar({ score }: { score: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm font-bold text-text-dark">{score}%</span>
+      <div className="h-2 flex-1 overflow-hidden rounded-full bg-primary/15">
+        <div
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ParticipantCard({
+  participant,
+}: {
+  participant: RecommendedParticipant;
+}) {
+  return (
+    <Link
+      href={`/dashboard/participants/${participant.id}`}
+      className="block rounded-lg border border-card-border bg-white p-4 transition-shadow hover:shadow-md"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+              <UserRound className="size-5 text-primary" />
+            </div>
+            <div className="min-w-0">
+              <h2 className="truncate text-base font-bold text-text-dark">
+                {participant.name}
+              </h2>
+              <p className="mt-1 text-xs text-text-body">
+                {participant.diagnosisTypeLabel ?? "診断タイプ未設定"}
+              </p>
+            </div>
+          </div>
+          <ChevronRight className="mt-1 size-4 shrink-0 text-text-body/60" />
+        </div>
+
+        <div className="rounded-lg bg-background px-3 py-3">
+          <div className="mb-2 flex items-center gap-2 text-xs font-medium text-text-body">
+            <Sparkles className="size-4 text-primary" />
+            相性スコア
+            <span className="ml-auto text-text-body">
+              {participant.bestOpportunityTitle}
+            </span>
+          </div>
+          <ScoreBar score={participant.matchScore} />
+        </div>
+
+        <dl className="grid gap-2 text-sm sm:grid-cols-2">
+          <div className="flex items-center gap-2 text-text-body">
+            <MapPin className="size-4 shrink-0 text-primary" />
+            <span className="truncate">
+              {participant.preferredLocation ?? participant.region}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-text-body">
+            <Tag className="size-4 shrink-0 text-primary" />
+            <span className="truncate">
+              {formatList(participant.interests, "興味カテゴリ未設定")}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-text-body sm:col-span-2">
+            <Brain className="size-4 shrink-0 text-primary" />
+            <span className="truncate">
+              {formatList(participant.availabilitySummary, "参加可能形態未設定")}
+            </span>
+          </div>
+        </dl>
+      </div>
+    </Link>
+  );
+}
+
+export default async function DashboardParticipantsPage() {
+  const { participants, emptyReason, error } =
+    await fetchRecommendedParticipants();
+
+  if (error === "ログインが必要です") {
+    redirect("/login");
+  }
+  if (error === "団体プロフィールが見つかりません") {
+    redirect("/onboarding/organization");
+  }
+  if (error === "承認済み団体のみ利用できます") {
+    redirect("/onboarding/pending");
+  }
+
+  const emptyState = emptyStateMessage(emptyReason);
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+
+      <main className="mx-auto max-w-4xl px-6 py-8">
+        <Link
+          href="/dashboard"
+          className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          ダッシュボードに戻る
+        </Link>
+
+        <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">
+              おすすめ参加者
+            </h1>
+            <p className="mt-2 text-sm text-text-body">
+              自団体の公開中募集案件に対する最高相性スコア順で表示しています。
+            </p>
+          </div>
+          <Link
+            href="/dashboard/opportunities/new"
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-dark"
+          >
+            <Sparkles className="size-4" />
+            募集案件を作成
+          </Link>
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-lg border border-card-border bg-white p-4 text-sm text-text-body">
+            {error}
+          </div>
+        )}
+
+        {participants.length > 0 ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {participants.map((participant) => (
+              <ParticipantCard
+                key={participant.id}
+                participant={participant}
+              />
+            ))}
+          </div>
+        ) : (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+                  {emptyReason === "no_published_opportunities" ? (
+                    <Users className="size-5 text-primary" />
+                  ) : (
+                    <SearchX className="size-5 text-primary" />
+                  )}
+                </div>
+                <h2 className="text-lg font-bold text-text-dark">
+                  {emptyState.title}
+                </h2>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm leading-6 text-text-body">
+                {emptyState.description}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -1,9 +1,15 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import type { BIG5Scores } from "@/lib/personality/types";
 import { calculateMatchScore } from "@/lib/recommendations/matching";
+import {
+  buildRecommendedParticipants,
+  type RecommendedParticipantCandidate,
+  type RecommendedParticipantOpportunity,
+} from "./recommended-participants";
 import type {
   DashboardData,
   DashboardOpportunity,
@@ -16,6 +22,8 @@ import type {
   ApplicantsResult,
   UpdateApplicationStatusResult,
   ApplicantDetailResult,
+  RecommendedParticipantDetailResult,
+  RecommendedParticipantsResult,
 } from "./types";
 import { PERSONALITY_TYPES } from "@/lib/personality/constants";
 
@@ -92,6 +100,182 @@ export async function fetchMyOpportunities(): Promise<DashboardData> {
   }
 
   return { opportunities };
+}
+
+async function fetchApprovedOrganizationProfile(
+  userId: string
+): Promise<{ id: string } | { error: string }> {
+  const organizationProfile = await prisma.organizationProfile.findUnique({
+    where: { userId },
+    select: { id: true, reviewStatus: true },
+  });
+
+  if (!organizationProfile) {
+    return { error: "団体プロフィールが見つかりません" };
+  }
+
+  if (organizationProfile.reviewStatus !== "approved") {
+    return { error: "承認済み団体のみ利用できます" };
+  }
+
+  return { id: organizationProfile.id };
+}
+
+async function fetchPublishedOpportunityRequirements(
+  organizationId: string
+): Promise<RecommendedParticipantOpportunity[]> {
+  return prisma.opportunity.findMany({
+    where: { organizationId, status: "published" },
+    select: { id: true, requirementTraits: true, title: true },
+  });
+}
+
+async function fetchPublicParticipantCandidates(): Promise<
+  RecommendedParticipantCandidate[]
+> {
+  return prisma.participantProfile.findMany({
+    where: { publicProfile: true },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      region: true,
+      bio: true,
+      interests: true,
+      availability: true,
+      preferredLocation: true,
+      publicProfile: true,
+      diagnosisType: true,
+      diagnosisMode: true,
+      diagnosisScores: true,
+    },
+  });
+}
+
+async function fetchRecommendedParticipantCandidate(
+  participantProfileId: string
+): Promise<RecommendedParticipantCandidate | null> {
+  return prisma.participantProfile.findUnique({
+    where: { id: participantProfileId },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      region: true,
+      bio: true,
+      interests: true,
+      availability: true,
+      preferredLocation: true,
+      publicProfile: true,
+      diagnosisType: true,
+      diagnosisMode: true,
+      diagnosisScores: true,
+    },
+  });
+}
+
+/**
+ * 団体向けおすすめ参加者一覧を取得する。
+ *
+ * 自団体の公開中募集案件ごとに参加者との相性を計算し、
+ * 参加者ごとの最高スコアを代表スコアとして返す。
+ */
+export async function fetchRecommendedParticipants(): Promise<RecommendedParticipantsResult> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { participants: [], error: "ログインが必要です" };
+    }
+
+    const organizationProfile = await fetchApprovedOrganizationProfile(user.id);
+    if ("error" in organizationProfile) {
+      return { participants: [], error: organizationProfile.error };
+    }
+
+    const opportunities = await fetchPublishedOpportunityRequirements(
+      organizationProfile.id
+    );
+    if (opportunities.length === 0) {
+      return {
+        participants: [],
+        emptyReason: "no_published_opportunities",
+      };
+    }
+
+    const candidates = await fetchPublicParticipantCandidates();
+    const participants = buildRecommendedParticipants(candidates, opportunities);
+
+    return {
+      participants,
+      emptyReason:
+        participants.length === 0 ? "no_recommended_participants" : undefined,
+    };
+  } catch (err) {
+    console.error("[fetchRecommendedParticipants] 予期しないエラー:", err);
+    return { participants: [], error: "予期しないエラーが発生しました" };
+  }
+}
+
+/**
+ * 団体向けおすすめ参加者の詳細を取得する。
+ *
+ * 非公開プロフィール、診断未実施プロフィール、存在しないプロフィールは
+ * 参加者なしとして扱う。
+ */
+export async function fetchRecommendedParticipantDetail(
+  participantProfileId: string
+): Promise<RecommendedParticipantDetailResult> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { participant: null, error: "ログインが必要です" };
+    }
+
+    const organizationProfile = await fetchApprovedOrganizationProfile(user.id);
+    if ("error" in organizationProfile) {
+      return { participant: null, error: organizationProfile.error };
+    }
+
+    const opportunities = await fetchPublishedOpportunityRequirements(
+      organizationProfile.id
+    );
+    if (opportunities.length === 0) {
+      return {
+        participant: null,
+        emptyReason: "no_published_opportunities",
+      };
+    }
+
+    const candidate = await fetchRecommendedParticipantCandidate(
+      participantProfileId
+    );
+    if (!candidate) {
+      return { participant: null, error: "参加者が見つかりません" };
+    }
+
+    const [participant] = buildRecommendedParticipants(
+      [candidate],
+      opportunities
+    );
+    if (!participant) {
+      return { participant: null, error: "参加者が見つかりません" };
+    }
+
+    return { participant };
+  } catch (err) {
+    console.error("[fetchRecommendedParticipantDetail] 予期しないエラー:", err);
+    return { participant: null, error: "予期しないエラーが発生しました" };
+  }
 }
 
 /** BIG5 特性キーの一覧 */

--- a/app/src/lib/dashboard/recommended-participants-actions.test.ts
+++ b/app/src/lib/dashboard/recommended-participants-actions.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  RecommendedParticipantDetailResult,
+  RecommendedParticipantsResult,
+} from "./types";
+
+const mockGetUser = vi.fn();
+const mockFindOrganizationProfile = vi.fn();
+const mockFindOpportunities = vi.fn();
+const mockFindParticipants = vi.fn();
+const mockFindParticipant = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mockGetUser(),
+    },
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    organizationProfile: {
+      findUnique: (...args: unknown[]) => mockFindOrganizationProfile(...args),
+    },
+    opportunity: {
+      findMany: (...args: unknown[]) => mockFindOpportunities(...args),
+    },
+    participantProfile: {
+      findMany: (...args: unknown[]) => mockFindParticipants(...args),
+      findUnique: (...args: unknown[]) => mockFindParticipant(...args),
+    },
+  },
+}));
+
+const { fetchRecommendedParticipantDetail, fetchRecommendedParticipants } =
+  await import("./actions");
+
+const completeScores = {
+  agreeableness: 50,
+  conscientiousness: 50,
+  extraversion: 50,
+  neuroticism: 50,
+  openness: 50,
+};
+
+const approvedOrganization = {
+  id: "org-profile-1",
+  reviewStatus: "approved",
+};
+
+describe("fetchRecommendedParticipants", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockReturnValue({ data: { user: { id: "org-user-1" } } });
+    mockFindOrganizationProfile.mockResolvedValue(approvedOrganization);
+    mockFindOpportunities.mockResolvedValue([
+      {
+        id: "opp-1",
+        title: "イベントリーダー",
+        requirementTraits: { extraversion: 80 },
+      },
+    ]);
+    mockFindParticipants.mockResolvedValue([
+      {
+        id: "profile-1",
+        userId: "participant-1",
+        name: "山田 花子",
+        region: "東京都",
+        bio: "地域活動が好きです",
+        interests: ["環境保全"],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: "innovator-leader",
+        diagnosisMode: "brief",
+        diagnosisScores: { ...completeScores, extraversion: 80 },
+      },
+    ]);
+  });
+
+  it("未ログインの場合はエラーを返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: null } });
+
+    const result: RecommendedParticipantsResult =
+      await fetchRecommendedParticipants();
+
+    expect(result.participants).toEqual([]);
+    expect(result.error).toBe("ログインが必要です");
+  });
+
+  it("未承認団体の場合はエラーを返す", async () => {
+    mockFindOrganizationProfile.mockResolvedValue({
+      id: "org-profile-1",
+      reviewStatus: "pending",
+    });
+
+    const result: RecommendedParticipantsResult =
+      await fetchRecommendedParticipants();
+
+    expect(result.participants).toEqual([]);
+    expect(result.error).toBe("承認済み団体のみ利用できます");
+  });
+
+  it("公開中募集案件がない場合は空状態理由を返す", async () => {
+    mockFindOpportunities.mockResolvedValue([]);
+
+    const result: RecommendedParticipantsResult =
+      await fetchRecommendedParticipants();
+
+    expect(result.participants).toEqual([]);
+    expect(result.emptyReason).toBe("no_published_opportunities");
+  });
+
+  it("公開済み・診断済み参加者を相性スコア順で返す", async () => {
+    const result: RecommendedParticipantsResult =
+      await fetchRecommendedParticipants();
+
+    expect(mockFindOrganizationProfile).toHaveBeenCalledWith({
+      where: { userId: "org-user-1" },
+      select: { id: true, reviewStatus: true },
+    });
+    expect(mockFindOpportunities).toHaveBeenCalledWith({
+      where: { organizationId: "org-profile-1", status: "published" },
+      select: { id: true, requirementTraits: true, title: true },
+    });
+    expect(mockFindParticipants).toHaveBeenCalledWith({
+      where: { publicProfile: true },
+      select: expect.objectContaining({
+        diagnosisScores: true,
+        publicProfile: true,
+      }),
+    });
+    expect(result.participants).toHaveLength(1);
+    expect(result.participants[0]).toMatchObject({
+      id: "profile-1",
+      matchScore: 100,
+      bestOpportunityTitle: "イベントリーダー",
+    });
+  });
+});
+
+describe("fetchRecommendedParticipantDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockReturnValue({ data: { user: { id: "org-user-1" } } });
+    mockFindOrganizationProfile.mockResolvedValue(approvedOrganization);
+    mockFindOpportunities.mockResolvedValue([
+      {
+        id: "opp-1",
+        title: "イベントリーダー",
+        requirementTraits: { extraversion: 80 },
+      },
+    ]);
+    mockFindParticipant.mockResolvedValue({
+      id: "profile-1",
+      userId: "participant-1",
+      name: "山田 花子",
+      region: "東京都",
+      bio: "地域活動が好きです",
+      interests: ["環境保全"],
+      availability: null,
+      preferredLocation: null,
+      publicProfile: true,
+      diagnosisType: "innovator-leader",
+      diagnosisMode: "brief",
+      diagnosisScores: { ...completeScores, extraversion: 80 },
+    });
+  });
+
+  it("指定参加者が公開済み・診断済みの場合は詳細を返す", async () => {
+    const result: RecommendedParticipantDetailResult =
+      await fetchRecommendedParticipantDetail("profile-1");
+
+    expect(mockFindParticipant).toHaveBeenCalledWith({
+      where: { id: "profile-1" },
+      select: expect.objectContaining({
+        diagnosisScores: true,
+        publicProfile: true,
+      }),
+    });
+    expect(result.participant).toMatchObject({
+      id: "profile-1",
+      matchScore: 100,
+      bestOpportunityId: "opp-1",
+    });
+  });
+
+  it("非公開または診断未実施の参加者は詳細を返さない", async () => {
+    mockFindParticipant.mockResolvedValue({
+      id: "profile-1",
+      userId: "participant-1",
+      name: "山田 花子",
+      region: "東京都",
+      bio: null,
+      interests: [],
+      availability: null,
+      preferredLocation: null,
+      publicProfile: false,
+      diagnosisType: null,
+      diagnosisMode: null,
+      diagnosisScores: completeScores,
+    });
+
+    const result: RecommendedParticipantDetailResult =
+      await fetchRecommendedParticipantDetail("profile-1");
+
+    expect(result.participant).toBeNull();
+    expect(result.error).toBe("参加者が見つかりません");
+  });
+});

--- a/app/src/lib/dashboard/recommended-participants.test.ts
+++ b/app/src/lib/dashboard/recommended-participants.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { buildRecommendedParticipants } from "./recommended-participants";
+
+const completeScores = {
+  agreeableness: 50,
+  conscientiousness: 50,
+  extraversion: 50,
+  neuroticism: 50,
+  openness: 50,
+};
+
+describe("buildRecommendedParticipants", () => {
+  it("公開済み・診断済み参加者を最高相性の募集案件スコア順で返す", () => {
+    const participants = [
+      {
+        id: "profile-1",
+        userId: "user-1",
+        name: "山田 花子",
+        region: "東京都",
+        interests: ["環境保全"],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: "innovator-leader",
+        diagnosisMode: "brief",
+        diagnosisScores: { ...completeScores, extraversion: 80 },
+      },
+      {
+        id: "profile-2",
+        userId: "user-2",
+        name: "佐藤 太郎",
+        region: "神奈川県",
+        interests: ["教育"],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: null,
+        diagnosisMode: null,
+        diagnosisScores: { ...completeScores, extraversion: 70 },
+      },
+    ];
+
+    const opportunities = [
+      {
+        id: "opp-1",
+        title: "落ち着いた事務サポート",
+        requirementTraits: { extraversion: 30 },
+      },
+      {
+        id: "opp-2",
+        title: "イベントリーダー",
+        requirementTraits: { extraversion: 80 },
+      },
+    ];
+
+    const result = buildRecommendedParticipants(participants, opportunities);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      id: "profile-1",
+      name: "山田 花子",
+      matchScore: 100,
+      bestOpportunityId: "opp-2",
+      bestOpportunityTitle: "イベントリーダー",
+      interests: ["環境保全"],
+    });
+    expect(result[1]).toMatchObject({
+      id: "profile-2",
+      matchScore: 90,
+      bestOpportunityId: "opp-2",
+    });
+  });
+
+  it("非公開プロフィールと診断スコア不正の参加者を除外する", () => {
+    const participants = [
+      {
+        id: "profile-public",
+        userId: "user-public",
+        name: "公開 参加者",
+        region: "東京都",
+        interests: [],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: null,
+        diagnosisMode: null,
+        diagnosisScores: completeScores,
+      },
+      {
+        id: "profile-private",
+        userId: "user-private",
+        name: "非公開 参加者",
+        region: "東京都",
+        interests: [],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: false,
+        diagnosisType: null,
+        diagnosisMode: null,
+        diagnosisScores: completeScores,
+      },
+      {
+        id: "profile-invalid",
+        userId: "user-invalid",
+        name: "未診断 参加者",
+        region: "東京都",
+        interests: [],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: null,
+        diagnosisMode: null,
+        diagnosisScores: { extraversion: 70 },
+      },
+    ];
+
+    const result = buildRecommendedParticipants(participants, [
+      {
+        id: "opp-1",
+        title: "環境イベント",
+        requirementTraits: { extraversion: 50 },
+      },
+    ]);
+
+    expect(result.map((participant) => participant.id)).toEqual([
+      "profile-public",
+    ]);
+  });
+
+  it("同点の場合は表示名、プロフィールIDの順で安定ソートする", () => {
+    const participants = [
+      {
+        id: "profile-b",
+        userId: "user-b",
+        name: "Bさん",
+        region: "東京都",
+        interests: [],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: null,
+        diagnosisMode: null,
+        diagnosisScores: completeScores,
+      },
+      {
+        id: "profile-a",
+        userId: "user-a",
+        name: "Aさん",
+        region: "東京都",
+        interests: [],
+        availability: null,
+        preferredLocation: null,
+        publicProfile: true,
+        diagnosisType: null,
+        diagnosisMode: null,
+        diagnosisScores: completeScores,
+      },
+    ];
+
+    const result = buildRecommendedParticipants(participants, [
+      {
+        id: "opp-1",
+        title: "地域イベント",
+        requirementTraits: completeScores,
+      },
+    ]);
+
+    expect(result.map((participant) => participant.id)).toEqual([
+      "profile-a",
+      "profile-b",
+    ]);
+  });
+
+  it("募集案件の要件特性が未指定の場合は既存仕様どおり50点にする", () => {
+    const result = buildRecommendedParticipants(
+      [
+        {
+          id: "profile-1",
+          userId: "user-1",
+          name: "山田 花子",
+          region: "東京都",
+          interests: [],
+          availability: null,
+          preferredLocation: null,
+          publicProfile: true,
+          diagnosisType: null,
+          diagnosisMode: null,
+          diagnosisScores: completeScores,
+        },
+      ],
+      [
+        {
+          id: "opp-1",
+          title: "要件未指定の募集",
+          requirementTraits: null,
+        },
+      ]
+    );
+
+    expect(result[0]).toMatchObject({
+      matchScore: 50,
+      bestOpportunityId: "opp-1",
+      bestOpportunityTitle: "要件未指定の募集",
+    });
+  });
+});

--- a/app/src/lib/dashboard/recommended-participants.ts
+++ b/app/src/lib/dashboard/recommended-participants.ts
@@ -1,0 +1,210 @@
+import type { BIG5Scores } from "@/lib/personality/types";
+import { PERSONALITY_TYPES } from "@/lib/personality/constants";
+import { calculateMatchScore } from "@/lib/recommendations/matching";
+
+const BIG5_TRAIT_KEYS = [
+  "extraversion",
+  "agreeableness",
+  "conscientiousness",
+  "neuroticism",
+  "openness",
+] as const;
+
+const BIG5_TRAIT_LABELS: Record<keyof BIG5Scores, string> = {
+  agreeableness: "協調性",
+  conscientiousness: "誠実性",
+  extraversion: "外向性",
+  neuroticism: "神経症傾向",
+  openness: "開放性",
+};
+
+export interface RecommendedParticipantCandidate {
+  id: string;
+  userId: string;
+  name: string;
+  region: string;
+  interests: unknown;
+  availability: unknown;
+  preferredLocation: string | null;
+  publicProfile: boolean;
+  diagnosisType: string | null;
+  diagnosisMode: string | null;
+  diagnosisScores: unknown;
+  bio?: string | null;
+}
+
+export interface RecommendedParticipantOpportunity {
+  id: string;
+  title: string;
+  requirementTraits: unknown;
+}
+
+export interface RecommendedParticipant {
+  id: string;
+  userId: string;
+  name: string;
+  region: string;
+  bio: string | null;
+  interests: string[];
+  availabilitySummary: string[];
+  preferredLocation: string | null;
+  diagnosisType: string | null;
+  diagnosisTypeLabel: string | null;
+  diagnosisMode: string | null;
+  diagnosisScores: BIG5Scores;
+  matchScore: number;
+  bestOpportunityId: string;
+  bestOpportunityTitle: string;
+  matchReasons: string[];
+}
+
+function isBIG5Scores(value: unknown): value is BIG5Scores {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return BIG5_TRAIT_KEYS.every((trait) => typeof obj[trait] === "number");
+}
+
+function toPartialBIG5Scores(value: unknown): Partial<BIG5Scores> {
+  if (!value || typeof value !== "object") return {};
+  const obj = value as Record<string, unknown>;
+  const result: Partial<BIG5Scores> = {};
+
+  for (const trait of BIG5_TRAIT_KEYS) {
+    const score = obj[trait];
+    if (typeof score === "number") {
+      result[trait] = score;
+    }
+  }
+
+  return result;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function summarizeAvailability(value: unknown): string[] {
+  if (!value || typeof value !== "object") return toStringArray(value);
+  if (Array.isArray(value)) return toStringArray(value);
+
+  const obj = value as Record<string, unknown>;
+  const weekdays = toStringArray(obj.weekdays);
+  const time = typeof obj.time === "string" ? obj.time : null;
+  return [
+    ...(weekdays.length > 0 ? [`${weekdays.join("・")}曜`] : []),
+    ...(time ? [time] : []),
+  ];
+}
+
+function resolveDiagnosisTypeLabel(diagnosisType: string | null): string | null {
+  if (!diagnosisType) return null;
+  return (
+    PERSONALITY_TYPES.find((type) => type.id === diagnosisType)?.name ??
+    PERSONALITY_TYPES.find((type) => type.name === diagnosisType)?.name ??
+    diagnosisType
+  );
+}
+
+function buildMatchReasons(
+  scores: BIG5Scores,
+  requirementTraits: Partial<BIG5Scores>
+): string[] {
+  const reasons = BIG5_TRAIT_KEYS.flatMap((trait) => {
+    const required = requirementTraits[trait];
+    if (required === undefined) return [];
+
+    const diff = Math.abs(scores[trait] - required);
+    if (diff <= 10) {
+      return [`${BIG5_TRAIT_LABELS[trait]}が募集条件に近い`];
+    }
+    return [];
+  });
+
+  return reasons.length > 0
+    ? reasons
+    : ["公開中募集案件の求める特性に基づいて算出しています"];
+}
+
+function selectBestMatch(
+  scores: BIG5Scores,
+  opportunities: RecommendedParticipantOpportunity[]
+): {
+  bestOpportunityId: string;
+  bestOpportunityTitle: string;
+  matchReasons: string[];
+  matchScore: number;
+} | null {
+  let best:
+    | {
+        bestOpportunityId: string;
+        bestOpportunityTitle: string;
+        matchReasons: string[];
+        matchScore: number;
+      }
+    | null = null;
+
+  for (const opportunity of opportunities) {
+    const requirementTraits = toPartialBIG5Scores(opportunity.requirementTraits);
+    const matchScore = calculateMatchScore(scores, requirementTraits);
+    if (!best || matchScore > best.matchScore) {
+      best = {
+        bestOpportunityId: opportunity.id,
+        bestOpportunityTitle: opportunity.title,
+        matchReasons: buildMatchReasons(scores, requirementTraits),
+        matchScore,
+      };
+    }
+  }
+
+  return best;
+}
+
+export function buildRecommendedParticipants(
+  participants: RecommendedParticipantCandidate[],
+  opportunities: RecommendedParticipantOpportunity[]
+): RecommendedParticipant[] {
+  if (opportunities.length === 0) return [];
+
+  return participants
+    .flatMap((participant) => {
+      if (!participant.publicProfile) return [];
+      if (!isBIG5Scores(participant.diagnosisScores)) return [];
+
+      const bestMatch = selectBestMatch(
+        participant.diagnosisScores,
+        opportunities
+      );
+      if (!bestMatch) return [];
+
+      return [
+        {
+          id: participant.id,
+          userId: participant.userId,
+          name: participant.name,
+          region: participant.region,
+          bio: participant.bio ?? null,
+          interests: toStringArray(participant.interests),
+          availabilitySummary: summarizeAvailability(participant.availability),
+          preferredLocation: participant.preferredLocation,
+          diagnosisType: participant.diagnosisType,
+          diagnosisTypeLabel: resolveDiagnosisTypeLabel(
+            participant.diagnosisType
+          ),
+          diagnosisMode: participant.diagnosisMode,
+          diagnosisScores: participant.diagnosisScores,
+          ...bestMatch,
+        },
+      ];
+    })
+    .sort((a, b) => {
+      if (a.matchScore !== b.matchScore) {
+        return b.matchScore - a.matchScore;
+      }
+
+      const nameOrder = a.name.localeCompare(b.name, "ja");
+      if (nameOrder !== 0) return nameOrder;
+
+      return a.id.localeCompare(b.id);
+    });
+}

--- a/app/src/lib/dashboard/types.ts
+++ b/app/src/lib/dashboard/types.ts
@@ -6,6 +6,8 @@
  * - applications: 各案件の応募者数（COUNT）
  */
 
+import type { RecommendedParticipant } from "./recommended-participants";
+
 /** 募集案件ステータス（DBスキーマ: draft / published / closed） */
 export type OpportunityStatus = "draft" | "published" | "closed";
 
@@ -141,6 +143,31 @@ export interface ApplicantDetail {
 export interface ApplicantDetailResult {
   /** 応募者詳細データ（見つからない場合は null） */
   data: ApplicantDetail | null;
+  /** エラーメッセージ */
+  error?: string;
+}
+
+/** おすすめ参加者一覧の空状態理由 */
+export type RecommendedParticipantsEmptyReason =
+  | "no_published_opportunities"
+  | "no_recommended_participants";
+
+/** fetchRecommendedParticipants の戻り値 */
+export interface RecommendedParticipantsResult {
+  /** 相性スコア順の参加者候補 */
+  participants: RecommendedParticipant[];
+  /** 表示すべき空状態の理由 */
+  emptyReason?: RecommendedParticipantsEmptyReason;
+  /** エラーメッセージ */
+  error?: string;
+}
+
+/** fetchRecommendedParticipantDetail の戻り値 */
+export interface RecommendedParticipantDetailResult {
+  /** 参加者詳細データ（見つからない場合は null） */
+  participant: RecommendedParticipant | null;
+  /** 表示すべき空状態の理由 */
+  emptyReason?: RecommendedParticipantsEmptyReason;
   /** エラーメッセージ */
   error?: string;
 }


### PR DESCRIPTION
## 概要
- 団体向けのおすすめ参加者一覧 `/dashboard/participants` と参加者詳細 `/dashboard/participants/[id]` を追加
- 自団体の公開中募集案件ごとに相性スコアを計算し、参加者ごとの最高スコアで候補を並び替え
- 公開プロフィールかつ診断済み参加者のみを候補にし、アプローチ送信は後続 issue 向けに準備中 CTA として表示

## 検証
- `npx vitest run src/lib/dashboard/recommended-participants.test.ts src/lib/dashboard/recommended-participants-actions.test.ts`
- `npm run lint`
- `npm run build`

## 関連 Issue
- Closes #109
