### PR TITLE
feat: 活動完了報告フローを実装

### DIFF
--- a/app/src/app/dashboard/opportunities/[id]/applicants/[applicationId]/page.tsx
+++ b/app/src/app/dashboard/opportunities/[id]/applicants/[applicationId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import {
   ArrowLeft,
+  CheckCircle2,
   User,
   MessageSquare,
   Sparkles,
@@ -170,6 +171,13 @@ export default async function ApplicantDetailPage({
                 応募日:{" "}
                 {new Date(data.created_at).toLocaleDateString("ja-JP")}
               </span>
+              {data.completed_at && (
+                <span className="flex items-center gap-1">
+                  <CheckCircle2 className="size-3" />
+                  完了日:{" "}
+                  {new Date(data.completed_at).toLocaleDateString("ja-JP")}
+                </span>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/app/src/app/dashboard/opportunities/[id]/components/StatusActions.tsx
+++ b/app/src/app/dashboard/opportunities/[id]/components/StatusActions.tsx
@@ -3,16 +3,17 @@
 import { useState, useTransition } from "react";
 import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
 import { updateApplicationStatus } from "@/lib/dashboard/actions";
+import type { ApplicationStatus } from "@/lib/dashboard/types";
 
 interface StatusActionsProps {
   /** 応募ID */
   applicationId: string;
   /** 現在のステータス */
-  currentStatus: "pending" | "approved" | "rejected";
+  currentStatus: ApplicationStatus;
 }
 
 /** ステータスに応じたバッジ表示 */
-function statusBadge(status: "pending" | "approved" | "rejected") {
+function statusBadge(status: ApplicationStatus) {
   switch (status) {
     case "pending":
       return {
@@ -23,6 +24,11 @@ function statusBadge(status: "pending" | "approved" | "rejected") {
       return {
         label: "承認済み",
         color: "text-green-700 bg-green-50 border-green-200",
+      };
+    case "completed":
+      return {
+        label: "活動完了",
+        color: "text-primary bg-primary/10 border-primary/20",
       };
     case "rejected":
       return {
@@ -36,7 +42,8 @@ function statusBadge(status: "pending" | "approved" | "rejected") {
  * 応募ステータスの承認/辞退ボタン（Client Component）
  *
  * - pending の場合: 承認・辞退ボタンを表示
- * - approved / rejected の場合: ステータスバッジを表示
+ * - approved の場合: 活動完了ボタンを表示
+ * - completed / rejected の場合: ステータスバッジを表示
  */
 export function StatusActions({
   applicationId,
@@ -46,7 +53,7 @@ export function StatusActions({
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  function handleAction(newStatus: "approved" | "rejected") {
+  function handleAction(newStatus: "approved" | "rejected" | "completed") {
     setError(null);
     startTransition(async () => {
       const result = await updateApplicationStatus(applicationId, newStatus);
@@ -58,17 +65,44 @@ export function StatusActions({
     });
   }
 
-  // 更新済みの場合はバッジ表示
+  if (status === "approved") {
+    const badge = statusBadge(status);
+    return (
+      <div className="flex flex-col items-end gap-2">
+        <span
+          className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium ${badge.color}`}
+        >
+          <CheckCircle2 className="size-3.5" />
+          {badge.label}
+        </span>
+        <button
+          onClick={() => handleAction("completed")}
+          disabled={isPending}
+          className="inline-flex cursor-pointer items-center gap-1 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-primary-dark disabled:pointer-events-none disabled:opacity-50"
+        >
+          {isPending ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <CheckCircle2 className="size-3.5" />
+          )}
+          活動完了にする
+        </button>
+        {error && <p className="text-xs text-red-600">{error}</p>}
+      </div>
+    );
+  }
+
+  // 完了・辞退済みの場合はバッジ表示
   if (status !== "pending") {
     const badge = statusBadge(status);
     return (
       <span
         className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium ${badge.color}`}
       >
-        {status === "approved" ? (
-          <CheckCircle2 className="size-3.5" />
-        ) : (
+        {status === "rejected" ? (
           <XCircle className="size-3.5" />
+        ) : (
+          <CheckCircle2 className="size-3.5" />
         )}
         {badge.label}
       </span>

--- a/app/src/app/dashboard/opportunities/[id]/page.tsx
+++ b/app/src/app/dashboard/opportunities/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import {
   ArrowLeft,
+  CheckCircle2,
   Users,
   Clock,
   Lock,
@@ -160,9 +161,18 @@ function ApplicantCard({
 
         {/* 応募日 + 詳細リンク */}
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1 text-xs text-text-body/70">
-            <Clock className="size-3" />
-            応募日: {new Date(applicant.created_at).toLocaleDateString("ja-JP")}
+          <div className="flex flex-col gap-1 text-xs text-text-body/70">
+            <span className="flex items-center gap-1">
+              <Clock className="size-3" />
+              応募日: {new Date(applicant.created_at).toLocaleDateString("ja-JP")}
+            </span>
+            {applicant.completed_at && (
+              <span className="flex items-center gap-1">
+                <CheckCircle2 className="size-3" />
+                完了日:{" "}
+                {new Date(applicant.completed_at).toLocaleDateString("ja-JP")}
+              </span>
+            )}
           </div>
           <Link
             href={`/dashboard/opportunities/${opportunityId}/applicants/${applicant.id}`}

--- a/app/src/app/mypage/page.tsx
+++ b/app/src/app/mypage/page.tsx
@@ -36,6 +36,12 @@ function statusDisplay(status: ApplicationStatus) {
         icon: <CheckCircle2 className="size-4" />,
         color: "text-green-700 bg-green-50 border-green-200",
       };
+    case "completed":
+      return {
+        label: "活動完了",
+        icon: <CheckCircle2 className="size-4" />,
+        color: "text-primary bg-primary/10 border-primary/20",
+      };
     case "rejected":
       return {
         label: "辞退",
@@ -220,8 +226,9 @@ export default async function MyPage() {
                           </span>
                         </div>
 
-                        {/* マッチング成立時のみ LINE ID を表示 */}
-                        {app.status === "approved" &&
+                        {/* マッチング成立後のみ LINE ID を表示 */}
+                        {(app.status === "approved" ||
+                          app.status === "completed") &&
                           app.opportunity.organization_line_id && (
                             <div className="flex items-center gap-2 rounded-lg bg-green-50 p-3">
                               <MessageCircle className="size-4 text-green-700" />
@@ -240,6 +247,14 @@ export default async function MyPage() {
                           応募日:{" "}
                           {new Date(app.created_at).toLocaleDateString("ja-JP")}
                         </p>
+                        {app.completed_at && (
+                          <p className="text-xs text-text-body">
+                            完了日:{" "}
+                            {new Date(app.completed_at).toLocaleDateString(
+                              "ja-JP"
+                            )}
+                          </p>
+                        )}
                       </div>
                     </div>
                   );

--- a/app/src/app/opportunities/[id]/page.tsx
+++ b/app/src/app/opportunities/[id]/page.tsx
@@ -32,6 +32,12 @@ function statusDisplay(status: ApplicationStatus) {
         icon: <CheckCircle2 className="size-4" />,
         color: "text-green-700 bg-green-50 border-green-200",
       };
+    case "completed":
+      return {
+        label: "活動完了",
+        icon: <CheckCircle2 className="size-4" />,
+        color: "text-primary bg-primary/10 border-primary/20",
+      };
     case "rejected":
       return {
         label: "辞退",
@@ -247,6 +253,14 @@ export default async function OpportunityDetailPage({
                     existingApplication.created_at
                   ).toLocaleDateString("ja-JP")}
                 </p>
+                {existingApplication.completed_at && (
+                  <p className="text-xs text-text-body">
+                    完了日:{" "}
+                    {new Date(
+                      existingApplication.completed_at
+                    ).toLocaleDateString("ja-JP")}
+                  </p>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -596,7 +596,9 @@ export async function fetchApplicantsForOpportunity(
     // 応募者一覧を取得（t_matching_candidate）
     const { data: matchingData } = await supabase
       .from("t_matching_candidate")
-      .select("id, status, message, match_score, applied_at, participant_id")
+      .select(
+        "id, status, message, match_score, applied_at, status_changed_at, participant_id"
+      )
       .eq("opportunity_id", opportunityId)
       .order("match_score", { ascending: false, nullsFirst: false })
       .order("applied_at", { ascending: false });
@@ -654,6 +656,8 @@ export async function fetchApplicantsForOpportunity(
         status: mapApplicationStatus(m.status as string),
         message: (m.message as string) ?? null,
         created_at: (m.applied_at as string) ?? "",
+        completed_at:
+          m.status === "completed" ? (m.status_changed_at as string) : null,
         participant_name: profile?.name ?? "不明",
         diagnosis_type: profile?.diagnosis_type ?? null,
         diagnosis_scores: profile?.diagnosis_scores ?? null,
@@ -703,7 +707,8 @@ export async function fetchApplicantsForOpportunity(
  */
 function mapApplicationStatus(dbStatus: string): Applicant["status"] {
   if (dbStatus === "applied" || dbStatus === "queued") return "pending";
-  if (dbStatus === "accepted" || dbStatus === "completed") return "approved";
+  if (dbStatus === "accepted") return "approved";
+  if (dbStatus === "completed") return "completed";
   if (dbStatus === "declined") return "rejected";
   return "pending";
 }
@@ -716,7 +721,7 @@ function mapApplicationStatus(dbStatus: string): Applicant["status"] {
  */
 export async function updateApplicationStatus(
   applicationId: string,
-  newStatus: "approved" | "rejected"
+  newStatus: "approved" | "rejected" | "completed"
 ): Promise<UpdateApplicationStatusResult> {
   try {
     const supabase = await createClient();
@@ -733,7 +738,7 @@ export async function updateApplicationStatus(
     // 応募データを取得
     const { data: appData, error: appError } = await supabase
       .from("t_matching_candidate")
-      .select("id, opportunity_id")
+      .select("id, opportunity_id, status")
       .eq("id", applicationId)
       .single();
 
@@ -764,13 +769,26 @@ export async function updateApplicationStatus(
       return { success: false, error: "この操作を行う権限がありません" };
     }
 
+    if (newStatus === "completed" && appData.status !== "accepted") {
+      return {
+        success: false,
+        error: "承認済みの応募のみ活動完了にできます",
+      };
+    }
+
     // UI ステータスを DB ステータスにマッピング
-    const dbStatus = newStatus === "approved" ? "accepted" : "declined";
+    const dbStatus =
+      newStatus === "approved"
+        ? "accepted"
+        : newStatus === "rejected"
+          ? "declined"
+          : "completed";
+    const now = new Date().toISOString();
 
     // ステータスを更新
     const { error: updateError } = await supabase
       .from("t_matching_candidate")
-      .update({ status: dbStatus })
+      .update({ status: dbStatus, status_changed_at: now, updated_at: now })
       .eq("id", applicationId);
 
     if (updateError) {
@@ -810,7 +828,9 @@ export async function fetchApplicantDetail(
     // 応募データを取得
     const { data: appData, error: appError } = await supabase
       .from("t_matching_candidate")
-      .select("id, status, message, match_score, applied_at, opportunity_id, participant_id")
+      .select(
+        "id, status, message, match_score, applied_at, status_changed_at, opportunity_id, participant_id"
+      )
       .eq("id", applicationId)
       .single();
 
@@ -887,6 +907,10 @@ export async function fetchApplicantDetail(
         status: mapApplicationStatus(appData.status as string),
         message: (appData.message as string) ?? null,
         created_at: (appData.applied_at as string) ?? "",
+        completed_at:
+          appData.status === "completed"
+            ? (appData.status_changed_at as string)
+            : null,
         participant_name: participant?.name ?? "不明",
         diagnosis_type: diagnosisTypeLabel,
         diagnosis_scores: participant?.diagnosis_scores ?? null,

--- a/app/src/lib/dashboard/applicants.test.ts
+++ b/app/src/lib/dashboard/applicants.test.ts
@@ -175,6 +175,7 @@ describe("fetchApplicantsForOpportunity", () => {
             message: "応募メッセージ",
             match_score: 75.5,
             applied_at: "2026-01-20T00:00:00Z",
+            status_changed_at: "2026-01-20T00:00:00Z",
             participant_id: "user-participant-1",
           },
         ],
@@ -214,7 +215,63 @@ describe("fetchApplicantsForOpportunity", () => {
     expect(applicant.participant_name).toBe("テスト太郎");
     expect(applicant.diagnosis_type).toBe("イノベーター・リーダー");
     expect(applicant.status).toBe("pending"); // DB: applied → UI: pending
+    expect(applicant.completed_at).toBeNull();
     expect(applicant.match_score).toBe(75.5);
+  });
+
+  it("活動完了済みの応募者は completed と完了日時を返す", async () => {
+    const mockUser = { id: "user-123" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    mockSingle
+      .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
+      .mockReturnValueOnce({
+        data: {
+          id: "opp-1",
+          title: "テスト案件",
+          description: null,
+          status: "published",
+          requirement_traits: null,
+          created_at: "2026-01-15T00:00:00Z",
+        },
+        error: null,
+      });
+
+    mockOrder.mockReturnValue(
+      createOrderResult({
+        data: [
+          {
+            id: "app-completed",
+            status: "completed",
+            message: null,
+            match_score: 85,
+            applied_at: "2026-01-20T00:00:00Z",
+            status_changed_at: "2026-02-01T09:30:00Z",
+            participant_id: "user-participant-completed",
+          },
+        ],
+        error: null,
+      })
+    );
+
+    mockIn.mockReturnValue({
+      data: [
+        {
+          user_id: "user-participant-completed",
+          name: "完了太郎",
+          diagnosis_type: null,
+          diagnosis_scores: null,
+        },
+      ],
+      error: null,
+    });
+
+    const result: ApplicantsResult =
+      await fetchApplicantsForOpportunity("opp-1");
+
+    const applicant = result.data!.applicants[0];
+    expect(applicant.status).toBe("completed");
+    expect(applicant.completed_at).toBe("2026-02-01T09:30:00Z");
   });
 
   it("応募者が0件の場合、空配列を返す", async () => {
@@ -428,7 +485,7 @@ describe("updateApplicationStatus", () => {
     // t_matching_candidate 取得成功
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       // m_organization_profile 取得失敗
@@ -447,7 +504,7 @@ describe("updateApplicationStatus", () => {
 
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
@@ -469,7 +526,7 @@ describe("updateApplicationStatus", () => {
 
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
@@ -481,7 +538,13 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "approved");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "accepted" }); // UI: approved → DB: accepted
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "accepted",
+        status_changed_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    ); // UI: approved → DB: accepted
     expect(mockFrom).toHaveBeenCalledWith("t_matching_candidate");
   });
 
@@ -491,7 +554,7 @@ describe("updateApplicationStatus", () => {
 
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
@@ -503,7 +566,60 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "rejected");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "declined" }); // UI: rejected → DB: declined
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "declined",
+        status_changed_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    ); // UI: rejected → DB: declined
+  });
+
+  it("承認済み応募を活動完了に更新できる", async () => {
+    const mockUser = { id: "user-123" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    mockSingle
+      .mockReturnValueOnce({
+        data: { id: "app-1", opportunity_id: "opp-1", status: "accepted" },
+        error: null,
+      })
+      .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
+      .mockReturnValueOnce({ data: { id: "opp-1" }, error: null });
+
+    mockUpdateEq.mockReturnValue({ error: null });
+
+    const result: UpdateApplicationStatusResult =
+      await updateApplicationStatus("app-1", "completed");
+
+    expect(result.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "completed",
+        status_changed_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    );
+  });
+
+  it("承認済み以外の応募は活動完了に更新できない", async () => {
+    const mockUser = { id: "user-123" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    mockSingle
+      .mockReturnValueOnce({
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
+        error: null,
+      })
+      .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
+      .mockReturnValueOnce({ data: { id: "opp-1" }, error: null });
+
+    const result: UpdateApplicationStatusResult =
+      await updateApplicationStatus("app-1", "completed");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("承認済みの応募のみ活動完了にできます");
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it("DB エラー時もクラッシュせずエラーを返す", async () => {
@@ -724,7 +840,7 @@ describe("updateApplicationStatus", () => {
     // 3回目: 案件の認可チェック → 失敗
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
@@ -750,7 +866,7 @@ describe("updateApplicationStatus", () => {
     // 応募データ取得
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       // 団体プロフィール取得
@@ -768,7 +884,13 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "approved");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "accepted" });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "accepted",
+        status_changed_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    );
     expect(mockFrom).toHaveBeenCalledWith("t_matching_candidate");
   });
 
@@ -781,7 +903,7 @@ describe("updateApplicationStatus", () => {
 
     mockSingle
       .mockReturnValueOnce({
-        data: { id: "app-1", opportunity_id: "opp-1" },
+        data: { id: "app-1", opportunity_id: "opp-1", status: "applied" },
         error: null,
       })
       .mockReturnValueOnce({ data: { id: "profile-123" }, error: null })
@@ -796,7 +918,13 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "rejected");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "declined" });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "declined",
+        status_changed_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    );
   });
 
   it("DB エラー時もクラッシュせずエラーを返す", async () => {

--- a/app/src/lib/dashboard/types.ts
+++ b/app/src/lib/dashboard/types.ts
@@ -53,7 +53,7 @@ export interface UpdateOpportunityResult {
 }
 
 /** 応募ステータス */
-export type ApplicationStatus = "pending" | "approved" | "rejected";
+export type ApplicationStatus = "pending" | "approved" | "rejected" | "completed";
 
 /** 応募者情報（applications + participants JOIN 結果） */
 export interface Applicant {
@@ -65,6 +65,8 @@ export interface Applicant {
   message: string | null;
   /** 応募日 */
   created_at: string;
+  /** 活動完了日 */
+  completed_at: string | null;
   /** 参加者名 */
   participant_name: string;
   /** 診断タイプ（10類型名） */
@@ -117,6 +119,8 @@ export interface ApplicantDetail {
   message: string | null;
   /** 応募日 */
   created_at: string;
+  /** 活動完了日 */
+  completed_at: string | null;
   /** 参加者名 */
   participant_name: string;
   /** 診断タイプ名（10類型名） */

--- a/app/src/lib/mypage/actions.test.ts
+++ b/app/src/lib/mypage/actions.test.ts
@@ -13,6 +13,7 @@ type MatchingRow = {
   message: string | null;
   created_at: string;
   applied_at: string | null;
+  status_changed_at: string;
   opportunity_id: string;
 };
 
@@ -169,6 +170,7 @@ describe("fetchMyPageData", () => {
         message: "応募メッセージ",
         created_at: "2026-01-01T00:00:00.000Z",
         applied_at: "2026-01-01T00:00:00.000Z",
+        status_changed_at: "2026-01-01T00:00:00.000Z",
         opportunity_id: "opp-1",
       },
       {
@@ -177,6 +179,7 @@ describe("fetchMyPageData", () => {
         message: null,
         created_at: "2026-01-02T00:00:00.000Z",
         applied_at: "2026-01-02T00:00:00.000Z",
+        status_changed_at: "2026-01-02T00:00:00.000Z",
         opportunity_id: "opp-2",
       },
     ];
@@ -205,12 +208,16 @@ describe("fetchMyPageData", () => {
 
     const pendingApp = result.applications[1];
     expect(pendingApp.status).toBe("pending");
+    expect(pendingApp.completed_at).toBeNull();
+    expect(pendingApp.can_request_certificate).toBe(false);
     expect(pendingApp.opportunity.title).toBe("環境保全ボランティア");
     expect(pendingApp.opportunity.organization_name).toBe("NPO法人テスト");
     expect(pendingApp.opportunity.organization_line_id).toBeNull();
 
     const approvedApp = result.applications[0];
     expect(approvedApp.status).toBe("approved");
+    expect(approvedApp.completed_at).toBeNull();
+    expect(approvedApp.can_request_certificate).toBe(false);
     expect(approvedApp.opportunity.title).toBe("子ども支援活動");
     expect(approvedApp.opportunity.organization_name).toBe("支援団体A");
     expect(approvedApp.opportunity.organization_line_id).toBe("@support_line");
@@ -236,6 +243,7 @@ describe("fetchMyPageData", () => {
         message: null,
         created_at: "2026-01-03T00:00:00.000Z",
         applied_at: "2026-01-03T00:00:00.000Z",
+        status_changed_at: "2026-01-03T00:00:00.000Z",
         opportunity_id: "opp-3",
       },
       {
@@ -244,6 +252,7 @@ describe("fetchMyPageData", () => {
         message: null,
         created_at: "2026-01-04T00:00:00.000Z",
         applied_at: "2026-01-04T00:00:00.000Z",
+        status_changed_at: "2026-02-10T12:34:00.000Z",
         opportunity_id: "opp-4",
       },
     ];
@@ -270,10 +279,14 @@ describe("fetchMyPageData", () => {
 
     const rejectedApp = result.applications[1];
     expect(rejectedApp.status).toBe("rejected");
+    expect(rejectedApp.completed_at).toBeNull();
+    expect(rejectedApp.can_request_certificate).toBe(false);
     expect(rejectedApp.opportunity.organization_line_id).toBeNull();
 
     const completedApp = result.applications[0];
-    expect(completedApp.status).toBe("approved");
+    expect(completedApp.status).toBe("completed");
+    expect(completedApp.completed_at).toBe("2026-02-10T12:34:00.000Z");
+    expect(completedApp.can_request_certificate).toBe(true);
     expect(completedApp.opportunity.organization_line_id).toBe(
       "@production_line"
     );

--- a/app/src/lib/mypage/actions.ts
+++ b/app/src/lib/mypage/actions.ts
@@ -29,9 +29,8 @@ const MATCHING_STATUS_TO_APPLICATION_STATUS: Record<
   ApplicationWithDetails["status"]
 > = {
   applied: "pending",
-  // accepted / completed は応募成立済みとして同じ UI（approved）で扱う
   accepted: "approved",
-  completed: "approved",
+  completed: "completed",
   declined: "rejected",
 };
 
@@ -103,7 +102,9 @@ export async function fetchMyPageData(): Promise<MyPageData> {
   try {
     const { data: candidateData, error: candidateError } = await supabase
       .from("t_matching_candidate")
-      .select("id, status, message, created_at, applied_at, opportunity_id")
+      .select(
+        "id, status, message, created_at, applied_at, status_changed_at, opportunity_id"
+      )
       .eq("participant_id", user.id)
       .in("status", [...MATCHING_CANDIDATE_STATUSES])
       .order("created_at", { ascending: false });
@@ -178,6 +179,10 @@ export async function fetchMyPageData(): Promise<MyPageData> {
         }
 
         const status = MATCHING_STATUS_TO_APPLICATION_STATUS[rawStatus];
+        const completedAt =
+          rawStatus === "completed"
+            ? (candidate.status_changed_at as string | null)
+            : null;
         return [
           {
             id: candidate.id as string,
@@ -186,12 +191,16 @@ export async function fetchMyPageData(): Promise<MyPageData> {
             created_at:
               (candidate.applied_at as string | null) ??
               (candidate.created_at as string),
+            completed_at: completedAt,
+            can_request_certificate: status === "completed",
             opportunity: {
               id: opportunityId,
               title: opportunity.title,
               organization_name: opportunity.organization_name,
               organization_line_id:
-                status === "approved" ? opportunity.organization_line_id : null,
+                status === "approved" || status === "completed"
+                  ? opportunity.organization_line_id
+                  : null,
             },
           },
         ];

--- a/app/src/lib/mypage/types.ts
+++ b/app/src/lib/mypage/types.ts
@@ -7,7 +7,7 @@
  */
 
 /** 応募ステータス */
-export type ApplicationStatus = "pending" | "approved" | "rejected";
+export type ApplicationStatus = "pending" | "approved" | "rejected" | "completed";
 
 /** 参加者プロフィール（participants テーブル） */
 export interface ParticipantProfile {
@@ -35,6 +35,8 @@ export interface ApplicationWithDetails {
   status: ApplicationStatus;
   message: string | null;
   created_at: string;
+  completed_at: string | null;
+  can_request_certificate: boolean;
   opportunity: ApplicationOpportunity;
 }
 

--- a/app/src/lib/opportunities/actions.test.ts
+++ b/app/src/lib/opportunities/actions.test.ts
@@ -166,6 +166,7 @@ describe("fetchOpportunityDetail", () => {
       status: "applied",
       message: "参加したいです",
       applied_at: "2026-01-15T00:00:00Z",
+      status_changed_at: "2026-01-15T00:00:00Z",
     };
 
     let callCount = 0;
@@ -182,7 +183,54 @@ describe("fetchOpportunityDetail", () => {
     expect(result.existingApplication).not.toBeNull();
     // DBステータス "applied" は UI では "pending" にマッピングされる
     expect(result.existingApplication?.status).toBe("pending");
+    expect(result.existingApplication?.completed_at).toBeNull();
     expect(result.existingApplication?.message).toBe("参加したいです");
+  });
+
+  it("活動完了済みの場合、existingApplication に completed と完了日時を含める", async () => {
+    const mockUser = { id: "user-123" };
+    mockGetUser.mockReturnValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    const mockOpp = {
+      id: "opp-1",
+      title: "子ども支援活動",
+      description: null,
+      requirement_traits: null,
+      status: "published",
+      created_at: "2026-01-01T00:00:00Z",
+      m_organization_profile: {
+        id: "org-2",
+        organization_name: "支援団体A",
+        description: null,
+      },
+    };
+
+    const mockApp = {
+      id: "app-1",
+      status: "completed",
+      message: "参加しました",
+      applied_at: "2026-01-15T00:00:00Z",
+      status_changed_at: "2026-02-01T10:00:00Z",
+    };
+
+    let callCount = 0;
+    mockSingle.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return { data: mockOpp, error: null };
+      if (callCount === 2) return { data: null, error: null };
+      return { data: mockApp, error: null };
+    });
+
+    const result: OpportunityDetailResult =
+      await fetchOpportunityDetail("opp-1");
+
+    expect(result.existingApplication?.status).toBe("completed");
+    expect(result.existingApplication?.completed_at).toBe(
+      "2026-02-01T10:00:00Z"
+    );
   });
 
   it("予期しないエラー時もクラッシュせず空データを返す", async () => {
@@ -380,6 +428,7 @@ describe("applyToOpportunity", () => {
         match_score: 75, // calculateMatchScore のモック戻り値
         message: "参加したいです",
         applied_at: expect.any(String),
+        status_changed_at: expect.any(String),
         created_at: expect.any(String),
         updated_at: expect.any(String),
       })

--- a/app/src/lib/opportunities/actions.ts
+++ b/app/src/lib/opportunities/actions.ts
@@ -147,7 +147,7 @@ export async function fetchOpportunityDetail(
 
     const { data: appData } = await supabase
       .from("t_matching_candidate")
-      .select("id, status, message, applied_at")
+      .select("id, status, message, applied_at, status_changed_at")
       .eq("opportunity_id", opportunityId)
       .eq("participant_id", user.id)
       .single();
@@ -158,6 +158,10 @@ export async function fetchOpportunityDetail(
         status: mapMatchingStatus(appData.status as string),
         message: (appData.message as string) ?? null,
         created_at: (appData.applied_at as string) ?? "",
+        completed_at:
+          appData.status === "completed"
+            ? (appData.status_changed_at as string)
+            : null,
       };
     }
 
@@ -183,7 +187,8 @@ export async function fetchOpportunityDetail(
  */
 function mapMatchingStatus(dbStatus: string): ExistingApplication["status"] {
   if (dbStatus === "applied" || dbStatus === "queued") return "pending";
-  if (dbStatus === "accepted" || dbStatus === "completed") return "approved";
+  if (dbStatus === "accepted") return "approved";
+  if (dbStatus === "completed") return "completed";
   if (dbStatus === "declined") return "rejected";
   return "pending";
 }
@@ -268,6 +273,7 @@ export async function applyToOpportunity(
         status: "applied",
         match_score: matchScore,
         applied_at: now,
+        status_changed_at: now,
         created_at: now,
         updated_at: now,
       });

--- a/app/src/lib/opportunities/types.ts
+++ b/app/src/lib/opportunities/types.ts
@@ -11,7 +11,7 @@
 export type OpportunityStatus = "draft" | "published" | "closed";
 
 /** 応募ステータス */
-export type ApplicationStatus = "pending" | "approved" | "rejected";
+export type ApplicationStatus = "pending" | "approved" | "rejected" | "completed";
 
 /** 募集団体情報 */
 export interface OrganizationInfo {
@@ -37,6 +37,7 @@ export interface ExistingApplication {
   status: ApplicationStatus;
   message: string | null;
   created_at: string;
+  completed_at: string | null;
 }
 
 /** fetchOpportunityDetail の戻り値 */


### PR DESCRIPTION
## 概要
- 団体側の承認済み応募に「活動完了にする」操作を追加
- `completed` ステータスを `approved` に丸めず、団体側・参加者側で「活動完了」として表示
- 既存の `status_changed_at` を活動完了日時として扱い、証明書申請の前提データを返すように変更

## 実装内容
- `updateApplicationStatus` を `completed` 更新に対応し、承認済み応募のみ活動完了へ変更可能に制限
- 応募者一覧・応募者詳細・参加者マイページ・案件詳細で完了日を表示
- 参加者マイページの応募データに `completed_at` / `can_request_certificate` を追加
- 応募作成時にも `status_changed_at` を保存
- 活動完了ステータスと完了日時のテストを追加

## 確認内容
- `cd app && npx vitest run src/lib/dashboard/applicants.test.ts src/lib/mypage/actions.test.ts src/lib/opportunities/actions.test.ts`
- `cd app && npm run test`
- `cd app && npm run lint`
- `cd app && npm run build`
- `git diff --check`

## 関連Issue
- Closes #111
