### PR TITLE
[codex] 本番DBマイグレーションを自動化

### DIFF
--- a/.github/workflows/production-db-migrate.yml
+++ b/.github/workflows/production-db-migrate.yml
@@ -1,0 +1,66 @@
+name: Production DB Migration
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/prisma/migrations/**"
+      - "app/prisma/schema.prisma"
+      - "app/prisma.config.ts"
+      - "app/package.json"
+      - "app/package-lock.json"
+      - ".github/workflows/production-db-migrate.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: production-db-migration
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Apply production Prisma migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app
+    env:
+      DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+      DIRECT_URL: ${{ secrets.PRODUCTION_DIRECT_URL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Validate production database secrets
+        shell: bash
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "PRODUCTION_DATABASE_URL GitHub Secret が設定されていません" >&2
+            exit 1
+          fi
+
+          if [ -z "$DIRECT_URL" ]; then
+            echo "PRODUCTION_DIRECT_URL GitHub Secret が設定されていません" >&2
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Show migration status
+        run: npx prisma migrate status
+        continue-on-error: true
+
+      - name: Apply pending migrations
+        run: npx prisma migrate deploy

--- a/docs/branch-workflow.md
+++ b/docs/branch-workflow.md
@@ -58,6 +58,30 @@ git push origin feature/my-feature
 | `preview` へのpush             | Preview                      |
 | `develop` / `feature/*` のpush | **スキップ（デプロイなし）** |
 
+## 本番DBマイグレーション
+
+`main` へのマージで Prisma migration 関連ファイルが更新された場合、GitHub Actions の `Production DB Migration` workflow が自動実行されます。
+
+対象ファイル:
+
+- `app/prisma/migrations/**`
+- `app/prisma/schema.prisma`
+- `app/prisma.config.ts`
+- `app/package.json`
+- `app/package-lock.json`
+- `.github/workflows/production-db-migrate.yml`
+
+workflow は `app/` で `npx prisma migrate deploy` を実行します。未適用 migration がなければ何も適用せず終了し、未適用 migration があれば本番DBへ適用します。手元の `app/.env.local` を本番用に書き換えて migration する運用は行いません。
+
+GitHub の `Repository` → `Settings` → `Secrets and variables` → `Actions` に以下を設定してください。
+
+| Secret名                  | 用途                                                                 |
+| ------------------------- | -------------------------------------------------------------------- |
+| `PRODUCTION_DATABASE_URL` | 本番アプリ用の PostgreSQL 接続文字列                                 |
+| `PRODUCTION_DIRECT_URL`   | Prisma migration 用の Supabase Session Mode Pooler 接続文字列（5432） |
+
+失敗時は GitHub の `Actions` → `Production DB Migration` でログを確認し、Secret や接続先を修正してから `Run workflow` で再実行します。
+
 ### ブランチ制限の設定（初回のみ・Vercelダッシュボード）
 
 Vercel → プロジェクト → **Settings → Git → Ignored Build Step** に以下を入力して保存：

--- a/docs/plans/2026-06-17-production-db-migration-plan.md
+++ b/docs/plans/2026-06-17-production-db-migration-plan.md
@@ -1,0 +1,66 @@
+# Production DB Migration Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `main` へのマージ後に本番 Prisma migration を GitHub Actions で自動適用する。
+
+**Architecture:** GitHub Actions workflow を追加し、`main` の migration 関連変更で `cd app && npx prisma migrate deploy` を実行する。接続情報は `.env.local` ではなく GitHub Actions Secrets から `DATABASE_URL` と `DIRECT_URL` にマッピングする。
+
+**Tech Stack:** GitHub Actions, Node.js, npm, Prisma 7, Supabase PostgreSQL
+
+---
+
+### Task 1: Workflow 構造検証
+
+**Files:**
+- Create: `scripts/verify-production-db-migration-workflow.mjs`
+- Create: `.github/workflows/production-db-migrate.yml`
+- Modify: `docs/branch-workflow.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+node scripts/verify-production-db-migration-workflow.mjs
+```
+
+Expected: `.github/workflows/production-db-migrate.yml` が存在しないため失敗する。
+
+- [ ] **Step 2: Add the production migration workflow**
+
+```yaml
+name: Production DB Migration
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/prisma/migrations/**"
+      - "app/prisma/schema.prisma"
+      - "app/prisma.config.ts"
+      - "app/package.json"
+      - "app/package-lock.json"
+      - ".github/workflows/production-db-migrate.yml"
+  workflow_dispatch:
+```
+
+Secrets は `PRODUCTION_DATABASE_URL` と `PRODUCTION_DIRECT_URL` を設定し、job 内で `DATABASE_URL` と `DIRECT_URL` にマッピングする。
+
+- [ ] **Step 3: Document required secrets and operation**
+
+`docs/branch-workflow.md` に GitHub Actions の場所、必要な Secret、失敗時の再実行方法を追記する。
+
+- [ ] **Step 4: Verify the workflow**
+
+```bash
+node scripts/verify-production-db-migration-workflow.mjs
+```
+
+Expected: `Production DB migration workflow verification passed.`
+
+- [ ] **Step 5: Check repository diff**
+
+```bash
+git diff -- .github/workflows/production-db-migrate.yml docs/branch-workflow.md scripts/verify-production-db-migration-workflow.mjs docs/plans/2026-06-17-production-db-migration-plan.md
+```
+
+Expected: workflow, docs, and verification script changes are scoped to production migration automation.

--- a/scripts/verify-production-db-migration-workflow.mjs
+++ b/scripts/verify-production-db-migration-workflow.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+
+const workflowPath = new URL(
+  "../.github/workflows/production-db-migrate.yml",
+  import.meta.url
+);
+
+assert.ok(
+  existsSync(workflowPath),
+  ".github/workflows/production-db-migrate.yml が存在しません"
+);
+
+const workflow = readFileSync(workflowPath, "utf8");
+
+function includesRequiredText(text, description) {
+  assert.ok(workflow.includes(text), `${description}: ${text}`);
+}
+
+function matchesRequiredPattern(pattern, description) {
+  assert.match(workflow, pattern, description);
+}
+
+includesRequiredText("name: Production DB Migration", "workflow 名が違います");
+matchesRequiredPattern(
+  /on:\n\s+push:\n\s+branches:\n\s+- main/,
+  "main push 限定のトリガーが必要です"
+);
+includesRequiredText("workflow_dispatch:", "手動再実行トリガーが必要です");
+includesRequiredText(
+  "app/prisma/migrations/**",
+  "migration 変更で起動する必要があります"
+);
+includesRequiredText("app/prisma/schema.prisma", "schema 変更で起動する必要があります");
+includesRequiredText("app/prisma.config.ts", "Prisma 設定変更で起動する必要があります");
+includesRequiredText("group: production-db-migration", "同時実行制限が必要です");
+includesRequiredText(
+  "cancel-in-progress: false",
+  "本番 migration の途中キャンセルは禁止です"
+);
+includesRequiredText(
+  "DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}",
+  "本番 DATABASE_URL Secret のマッピングが必要です"
+);
+includesRequiredText(
+  "DIRECT_URL: ${{ secrets.PRODUCTION_DIRECT_URL }}",
+  "本番 DIRECT_URL Secret のマッピングが必要です"
+);
+includesRequiredText(
+  "working-directory: app",
+  "Prisma コマンドは app で実行する必要があります"
+);
+includesRequiredText("npm ci", "lockfile に基づく依存関係インストールが必要です");
+includesRequiredText(
+  "npx prisma migrate deploy",
+  "本番 migration は deploy を使う必要があります"
+);
+
+assert.ok(
+  !workflow.includes("prisma migrate dev"),
+  "本番 workflow で prisma migrate dev を使ってはいけません"
+);
+assert.ok(
+  !workflow.includes(".env.local"),
+  "本番 workflow で .env.local を参照してはいけません"
+);
+
+console.log("Production DB migration workflow verification passed.");


### PR DESCRIPTION
## Summary
- `main` への migration 関連変更マージ時に本番 Prisma migration を自動実行する GitHub Actions workflow を追加
- GitHub Actions Secrets の `PRODUCTION_DATABASE_URL` / `PRODUCTION_DIRECT_URL` を `DATABASE_URL` / `DIRECT_URL` にマッピング
- ブランチ運用ドキュメントに必要な Secret と再実行手順を追記
- workflow の重要条件を検証するスクリプトと実装計画を追加

## Validation
- `node scripts/verify-production-db-migration-workflow.mjs`
- `node --check scripts/verify-production-db-migration-workflow.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/production-db-migrate.yml'); puts 'YAML syntax ok'"`
- `git diff --cached --check`

## Notes
- 本番 migration は `npx prisma migrate deploy` を使用します。
- `PRODUCTION_DIRECT_URL` は Supabase Session Mode Pooler の 5432 側を想定しています。