### PR TITLE
[codex] 団体登録でLINE IDを必須化

### DIFF
--- a/app/src/app/onboarding/organization/components/OrganizationProfileForm.test.tsx
+++ b/app/src/app/onboarding/organization/components/OrganizationProfileForm.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OrganizationProfileForm } from "./OrganizationProfileForm";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  registerOrganization: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}));
+
+vi.mock("@/lib/onboarding/actions", () => ({
+  registerOrganization: mocks.registerOrganization,
+}));
+
+describe("OrganizationProfileForm", () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.registerOrganization.mockReset();
+    mocks.registerOrganization.mockResolvedValue({ success: true });
+  });
+
+  it("LINE公式アカウントIDを必須項目として表示する", () => {
+    render(<OrganizationProfileForm />);
+
+    expect(screen.getByRole("heading", { name: "LINE 連携" })).toBeDefined();
+    expect(screen.queryByText("LINE 連携（任意）")).toBeNull();
+    expect(
+      screen.getByText(
+        "参加者との連絡に使用する団体・公式LINEアカウントのIDを入力してください。"
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "個人アカウントではなく、団体で管理できるアカウントの利用を推奨します。"
+      )
+    ).toBeDefined();
+
+    const lineIdInput = screen.getByLabelText(
+      "LINE公式アカウントID"
+    ) as HTMLInputElement;
+    expect(lineIdInput.required).toBe(true);
+    expect(screen.getByLabelText("LINE 友達追加 URL")).toBeDefined();
+  });
+
+  it("LINE公式アカウントIDが未入力の場合は登録処理を中断する", async () => {
+    render(<OrganizationProfileForm />);
+
+    fireEvent.change(screen.getByLabelText("団体名"), {
+      target: { value: "NPO法人テスト" },
+    });
+    fireEvent.change(screen.getByLabelText("代表者名"), {
+      target: { value: "山田 太郎" },
+    });
+    fireEvent.change(screen.getByLabelText("連絡先メールアドレス"), {
+      target: { value: "contact@example.org" },
+    });
+    fireEvent.click(screen.getByLabelText("東京都"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "登録して審査を申請する" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("LINE公式アカウントIDは必須です")).toBeDefined();
+    });
+    expect(mocks.registerOrganization).not.toHaveBeenCalled();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/app/onboarding/organization/components/OrganizationProfileForm.tsx
+++ b/app/src/app/onboarding/organization/components/OrganizationProfileForm.tsx
@@ -6,7 +6,6 @@ import {
   Building2,
   User,
   Mail,
-  MapPin,
   Globe,
   FileText,
   Tag,
@@ -94,6 +93,13 @@ export function OrganizationProfileForm({
     setLoading(true);
 
     try {
+      const normalizedContactLineId = contactLineId.trim();
+      if (!normalizedContactLineId) {
+        setError("LINE公式アカウントIDは必須です");
+        setLoading(false);
+        return;
+      }
+
       const result = await registerOrganization({
         organizationName,
         representativeName,
@@ -103,7 +109,7 @@ export function OrganizationProfileForm({
         activityCategories: activityCategories.length > 0 ? activityCategories : undefined,
         websiteUrl: websiteUrl || undefined,
         logoUrl: logoUrl || undefined,
-        contactLineId: contactLineId || undefined,
+        contactLineId: normalizedContactLineId,
         contactLineUrl: contactLineUrl || undefined,
       });
 
@@ -143,7 +149,7 @@ export function OrganizationProfileForm({
           </p>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-8">
+          <form onSubmit={handleSubmit} className="flex flex-col gap-8" noValidate>
             {/* 基本情報セクション */}
             <section className="flex flex-col gap-5">
               <div className="flex items-center gap-2 border-b border-card-border pb-2">
@@ -273,18 +279,20 @@ export function OrganizationProfileForm({
             <section className="flex flex-col gap-5">
               <div className="flex items-center gap-2 border-b border-card-border pb-2">
                 <MessageCircle className="size-5 text-primary" />
-                <h2 className="text-lg font-bold text-text-dark">LINE 連携（任意）</h2>
+                <h2 className="text-lg font-bold text-text-dark">LINE 連携</h2>
               </div>
-              <p className="text-xs text-text-body">
-                マッチング成立後のスムーズな連絡のため、公式LINE等の登録を推奨しています。
-              </p>
+              <div className="flex flex-col gap-1 text-xs text-text-body">
+                <p>参加者との連絡に使用する団体・公式LINEアカウントのIDを入力してください。</p>
+                <p>個人アカウントではなく、団体で管理できるアカウントの利用を推奨します。</p>
+              </div>
               <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
                 <Input
-                  label="LINE ID"
+                  label="LINE公式アカウントID"
                   icon={MessageCircle}
                   placeholder="@volunty_npo"
                   value={contactLineId}
                   onChange={(e) => setContactLineId(e.target.value)}
+                  required
                 />
                 <Input
                   label="LINE 友達追加 URL"

--- a/app/src/lib/onboarding/actions.test.ts
+++ b/app/src/lib/onboarding/actions.test.ts
@@ -362,6 +362,7 @@ describe("registerOrganization", () => {
       representativeName: "山田 太郎",
       contactEmail: "contact@example.org",
       activityAreas: ["東京都"],
+      contactLineId: "@test_org",
     });
 
     expect(result.success).toBe(false);
@@ -377,6 +378,7 @@ describe("registerOrganization", () => {
       representativeName: "山田 太郎",
       contactEmail: "contact@example.org",
       activityAreas: ["東京都"],
+      contactLineId: "@test_org",
     });
 
     expect(result.success).toBe(false);
@@ -392,6 +394,7 @@ describe("registerOrganization", () => {
       representativeName: "",
       contactEmail: "contact@example.org",
       activityAreas: ["東京都"],
+      contactLineId: "@test_org",
     });
 
     expect(result.success).toBe(false);
@@ -407,6 +410,7 @@ describe("registerOrganization", () => {
       representativeName: "山田 太郎",
       contactEmail: "",
       activityAreas: ["東京都"],
+      contactLineId: "@test_org",
     });
 
     expect(result.success).toBe(false);
@@ -422,6 +426,7 @@ describe("registerOrganization", () => {
       representativeName: "山田 太郎",
       contactEmail: "contact@example.org",
       activityAreas: [],
+      contactLineId: "@test_org",
     });
 
     expect(result.success).toBe(false);
@@ -429,7 +434,23 @@ describe("registerOrganization", () => {
     expect(mockPrismaOrgUpsert).not.toHaveBeenCalled();
   });
 
-  it("必須フィールドのみで正常登録できる（充実度40）", async () => {
+  it("LINE公式アカウントIDが空の場合、バリデーションエラーを返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-123" } } });
+
+    const result = await registerOrganization({
+      organizationName: "NPO法人テスト",
+      representativeName: "山田 太郎",
+      contactEmail: "contact@example.org",
+      activityAreas: ["東京都"],
+      contactLineId: "   ",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("LINE公式アカウントIDは必須です");
+    expect(mockPrismaOrgUpsert).not.toHaveBeenCalled();
+  });
+
+  it("必須フィールドのみで正常登録できる（充実度50）", async () => {
     mockGetUser.mockReturnValue({ data: { user: { id: "user-123" } } });
     mockPrismaOrgUpsert.mockResolvedValue({});
     mockUpdateUser.mockReturnValue({ error: null });
@@ -439,6 +460,7 @@ describe("registerOrganization", () => {
       representativeName: "山田 太郎",
       contactEmail: "contact@example.org",
       activityAreas: ["東京都"],
+      contactLineId: "  @test_org  ",
     });
 
     expect(result.success).toBe(true);
@@ -450,7 +472,14 @@ describe("registerOrganization", () => {
           representativeName: "山田 太郎",
           contactEmail: "contact@example.org",
           activityAreas: ["東京都"],
-          profileCompleteness: 40,
+          contactLineId: "@test_org",
+          contactLineUrl: null,
+          profileCompleteness: 50,
+        }),
+        update: expect.objectContaining({
+          contactLineId: "@test_org",
+          contactLineUrl: null,
+          profileCompleteness: 50,
         }),
       })
     );
@@ -496,6 +525,7 @@ describe("registerOrganization", () => {
       representativeName: "山田 太郎",
       contactEmail: "contact@example.org",
       activityAreas: ["東京都"],
+      contactLineId: "@test_org",
     });
 
     expect(mockUpdateUser).toHaveBeenCalledWith({

--- a/app/src/lib/onboarding/actions.ts
+++ b/app/src/lib/onboarding/actions.ts
@@ -141,13 +141,11 @@ export async function registerParticipant(
 /**
  * 団体プロフィール充実度スコアを計算する（0-100）
  *
- * - 必須4項目（各10点）: 40点
+ * - 必須5項目（各10点）: 50点
  * - 団体説明: 20点
  * - 活動カテゴリ: 10点
  * - ウェブサイトURL: 10点
  * - ロゴURL: 10点
- * - LINE ID: 5点
- * - LINE URL: 5点
  */
 function calcProfileCompleteness(data: RegisterOrganizationData): number {
   let score = 0;
@@ -155,12 +153,11 @@ function calcProfileCompleteness(data: RegisterOrganizationData): number {
   if (data.representativeName?.trim()) score += 10;
   if (data.contactEmail?.trim()) score += 10;
   if (data.activityAreas && data.activityAreas.length > 0) score += 10;
+  if (data.contactLineId.trim()) score += 10;
   if (data.description?.trim()) score += 20;
   if (data.activityCategories && data.activityCategories.length > 0) score += 10;
   if (data.websiteUrl?.trim()) score += 10;
   if (data.logoUrl?.trim()) score += 10;
-  if (data.contactLineId?.trim()) score += 5;
-  if (data.contactLineUrl?.trim()) score += 5;
   return score;
 }
 
@@ -194,8 +191,13 @@ export async function registerOrganization(
     if (!data.activityAreas || data.activityAreas.length === 0) {
       return { success: false, error: "活動地域を1つ以上選択してください" };
     }
+    if (!data.contactLineId?.trim()) {
+      return { success: false, error: "LINE公式アカウントIDは必須です" };
+    }
 
     const profileCompleteness = calcProfileCompleteness(data);
+    const normalizedContactLineId = data.contactLineId.trim();
+    const normalizedContactLineUrl = data.contactLineUrl?.trim() || null;
 
     const normalizedActivityCategories =
       data.activityCategories && data.activityCategories.length > 0
@@ -217,8 +219,8 @@ export async function registerOrganization(
         activityCategories: normalizedActivityCategories,
         websiteUrl: data.websiteUrl?.trim() || null,
         logoUrl: data.logoUrl?.trim() || null,
-        contactLineId: data.contactLineId?.trim() || null,
-        contactLineUrl: data.contactLineUrl?.trim() || null,
+        contactLineId: normalizedContactLineId,
+        contactLineUrl: normalizedContactLineUrl,
         reviewStatus: "pending",
         reviewComment: null,
         reviewedAt: null,
@@ -236,8 +238,8 @@ export async function registerOrganization(
         activityCategories: normalizedActivityCategories,
         websiteUrl: data.websiteUrl?.trim() || null,
         logoUrl: data.logoUrl?.trim() || null,
-        contactLineId: data.contactLineId?.trim() || null,
-        contactLineUrl: data.contactLineUrl?.trim() || null,
+        contactLineId: normalizedContactLineId,
+        contactLineUrl: normalizedContactLineUrl,
         reviewStatus: "pending",
         reviewComment: null,
         reviewedAt: null,

--- a/app/src/lib/onboarding/types.ts
+++ b/app/src/lib/onboarding/types.ts
@@ -10,8 +10,8 @@ export interface RegisterOrganizationData {
   activityCategories?: string[];
   websiteUrl?: string;
   logoUrl?: string;
-  // Step 3: 連絡手段（任意）
-  contactLineId?: string;
+  // Step 3: 連絡手段
+  contactLineId: string;
   contactLineUrl?: string;
 }
 


### PR DESCRIPTION
## 概要

- 団体プロフィール登録・編集フォームで LINE 公式アカウント ID を必須項目として表示
- `registerOrganization` で LINE ID 未入力を拒否し、trim 済みの値を保存
- `RegisterOrganizationData.contactLineId` を必須型に変更
- LINE ID 必須化に合わせてプロフィール充実度スコアを見直し
- フォームと Server Action の回帰テストを追加

Closes #119

## 検証

- `npm run lint`
  - exit 0
  - 既存警告: `src/lib/dashboard/update-opportunity.test.ts:15:33 _args`
- `npm run test`
  - 33 files / 221 tests passed
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build`
  - exit 0
  - 既存ログ: `/diagnosis/result` の `DYNAMIC_SERVER_USAGE`
