### PR TITLE
feat: 募集案件フォーム・DB項目をMVP仕様に合わせて補完する

### DIFF
--- a/app/prisma/migrations/20260619000000_add_opportunity_category_participation_mode/migration.sql
+++ b/app/prisma/migrations/20260619000000_add_opportunity_category_participation_mode/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "participation_mode" AS ENUM ('online', 'offline', 'hybrid');
+
+-- AlterTable
+ALTER TABLE "m_opportunity" ADD COLUMN "category" VARCHAR(50),
+ADD COLUMN "participation_mode" "participation_mode";

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -32,6 +32,15 @@ enum OpportunityStatus {
   @@map("opportunity_status")
 }
 
+/// 参加形態
+enum ParticipationMode {
+  online // オンライン
+  offline // オフライン（対面）
+  hybrid // ハイブリッド
+
+  @@map("participation_mode")
+}
+
 /// マッチング（応募）ステータス
 enum MatchingStatus {
   queued // キュー待ち（レコメンド生成済み）
@@ -203,6 +212,8 @@ model Opportunity {
   startDate         DateTime?         @map("start_date") @db.Date
   endDate           DateTime?         @map("end_date") @db.Date
   capacity          Int?
+  category          String?           @db.VarChar(50) // カテゴリ
+  participationMode ParticipationMode? @map("participation_mode") // 参加形態
   currentApplicants Int               @default(0) @map("current_applicants")
   status            OpportunityStatus @default(draft)
   publishedAt       DateTime?         @map("published_at")

--- a/app/src/app/dashboard/opportunities/[id]/edit/page.tsx
+++ b/app/src/app/dashboard/opportunities/[id]/edit/page.tsx
@@ -46,6 +46,12 @@ export default async function EditOpportunityPage({
             description: opportunity.description,
             required_traits: opportunity.required_traits,
             status: opportunity.status,
+            location: opportunity.location,
+            start_date: opportunity.start_date,
+            end_date: opportunity.end_date,
+            capacity: opportunity.capacity,
+            category: opportunity.category,
+            participation_mode: opportunity.participation_mode,
           }}
         />
       </main>

--- a/app/src/app/dashboard/opportunities/components/OpportunityForm.tsx
+++ b/app/src/app/dashboard/opportunities/components/OpportunityForm.tsx
@@ -9,11 +9,20 @@ import {
   ArrowLeft,
   Plus,
   Save,
+  MapPin,
+  Calendar,
+  Users,
+  Tag,
+  Globe,
 } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
 import { Button } from "@/app/components/ui/Button";
 import { Input } from "@/app/components/ui/Input";
-import type { OpportunityStatus } from "@/lib/dashboard/types";
+import type { OpportunityStatus, ParticipationMode } from "@/lib/dashboard/types";
+import {
+  CATEGORY_OPTIONS,
+  PARTICIPATION_MODE_OPTIONS,
+} from "@/lib/opportunities/constants";
 
 /** BIG5 特性の日本語ラベル */
 const BIG5_TRAITS = [
@@ -30,6 +39,18 @@ export interface OpportunityFormData {
   description: string;
   required_traits: Record<string, number> | null;
   status?: OpportunityStatus;
+  /** 活動場所 */
+  location?: string | null;
+  /** 開始日（YYYY-MM-DD） */
+  start_date?: string | null;
+  /** 終了日（YYYY-MM-DD） */
+  end_date?: string | null;
+  /** 定員 */
+  capacity?: number | null;
+  /** カテゴリ */
+  category?: string | null;
+  /** 参加形態 */
+  participation_mode?: ParticipationMode | null;
 }
 
 interface OpportunityFormProps {
@@ -183,6 +204,124 @@ export function OpportunityForm({
                 placeholder="活動内容、日時、場所、参加条件などを記載してください"
                 className="w-full rounded-lg border border-input-border bg-white py-2 pl-10 pr-3 text-sm text-text-dark placeholder:text-text-body focus:outline-none focus:ring-2 focus:ring-primary/30"
               />
+            </div>
+          </div>
+
+          {/* 募集情報 */}
+          <div className="flex flex-col gap-4">
+            {/* 活動場所 */}
+            <Input
+              label="活動場所（任意）"
+              name="location"
+              icon={MapPin}
+              type="text"
+              placeholder="例: 渋谷区 / オンライン"
+              defaultValue={initialData?.location ?? ""}
+            />
+
+            {/* 開始日・終了日 */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="startDate"
+                  className="text-sm font-medium text-text-dark"
+                >
+                  開始日（任意）
+                </label>
+                <div className="relative">
+                  <Calendar className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-body" />
+                  <input
+                    id="startDate"
+                    name="startDate"
+                    type="date"
+                    defaultValue={initialData?.start_date ?? ""}
+                    className="w-full rounded-lg border border-input-border bg-white py-2 pl-10 pr-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="endDate"
+                  className="text-sm font-medium text-text-dark"
+                >
+                  終了日（任意）
+                </label>
+                <div className="relative">
+                  <Calendar className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-body" />
+                  <input
+                    id="endDate"
+                    name="endDate"
+                    type="date"
+                    defaultValue={initialData?.end_date ?? ""}
+                    className="w-full rounded-lg border border-input-border bg-white py-2 pl-10 pr-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* 定員 */}
+            <Input
+              label="定員（任意）"
+              name="capacity"
+              icon={Users}
+              type="number"
+              min={1}
+              placeholder="例: 10"
+              defaultValue={
+                initialData?.capacity != null ? String(initialData.capacity) : ""
+              }
+            />
+
+            {/* カテゴリ */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="category"
+                className="text-sm font-medium text-text-dark"
+              >
+                カテゴリ（任意）
+              </label>
+              <div className="relative">
+                <Tag className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-body" />
+                <select
+                  id="category"
+                  name="category"
+                  defaultValue={initialData?.category ?? ""}
+                  className="w-full appearance-none rounded-lg border border-input-border bg-white py-2 pl-10 pr-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+                >
+                  <option value="">指定しない</option>
+                  {CATEGORY_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* 参加形態 */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="participationMode"
+                className="text-sm font-medium text-text-dark"
+              >
+                参加形態（任意）
+              </label>
+              <div className="relative">
+                <Globe className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-body" />
+                <select
+                  id="participationMode"
+                  name="participationMode"
+                  defaultValue={initialData?.participation_mode ?? ""}
+                  className="w-full appearance-none rounded-lg border border-input-border bg-white py-2 pl-10 pr-3 text-sm text-text-dark focus:outline-none focus:ring-2 focus:ring-primary/30"
+                >
+                  <option value="">指定しない</option>
+                  {PARTICIPATION_MODE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
           </div>
 

--- a/app/src/app/opportunities/[id]/page.tsx
+++ b/app/src/app/opportunities/[id]/page.tsx
@@ -8,12 +8,18 @@ import {
   ArrowLeft,
   Brain,
   Sparkles,
+  MapPin,
+  Calendar,
+  Users,
+  Tag,
+  Globe,
 } from "lucide-react";
 import { Header } from "@/app/components/Header";
 import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
 import { createClient } from "@/lib/supabase/server";
 import { fetchOpportunityDetail } from "@/lib/opportunities/actions";
 import type { ApplicationStatus } from "@/lib/opportunities/types";
+import { PARTICIPATION_MODE_OPTIONS } from "@/lib/opportunities/constants";
 import { TraitVisualization } from "./components/TraitVisualization";
 import { ApplyForm } from "./components/ApplyForm";
 
@@ -159,6 +165,78 @@ export default async function OpportunityDetailPage({
               <p className="whitespace-pre-wrap text-sm leading-6 text-text-body">
                 {opportunity.description}
               </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* 募集情報 */}
+        {(opportunity.location ||
+          opportunity.start_date ||
+          opportunity.end_date ||
+          opportunity.capacity !== null ||
+          opportunity.category ||
+          opportunity.participation_mode) && (
+          <Card className="mb-6">
+            <CardHeader>
+              <h2 className="text-lg font-bold text-text-dark">募集情報</h2>
+            </CardHeader>
+            <CardContent>
+              <dl className="flex flex-col gap-3 text-sm">
+                {opportunity.location && (
+                  <div className="flex items-center gap-3">
+                    <MapPin className="size-4 shrink-0 text-primary" />
+                    <dt className="w-24 shrink-0 text-text-body">活動場所</dt>
+                    <dd className="text-text-dark">{opportunity.location}</dd>
+                  </div>
+                )}
+                {(opportunity.start_date || opportunity.end_date) && (
+                  <div className="flex items-center gap-3">
+                    <Calendar className="size-4 shrink-0 text-primary" />
+                    <dt className="w-24 shrink-0 text-text-body">開催期間</dt>
+                    <dd className="text-text-dark">
+                      {opportunity.start_date
+                        ? new Date(opportunity.start_date).toLocaleDateString(
+                            "ja-JP"
+                          )
+                        : "未定"}
+                      {" 〜 "}
+                      {opportunity.end_date
+                        ? new Date(opportunity.end_date).toLocaleDateString(
+                            "ja-JP"
+                          )
+                        : "未定"}
+                    </dd>
+                  </div>
+                )}
+                {opportunity.capacity !== null && (
+                  <div className="flex items-center gap-3">
+                    <Users className="size-4 shrink-0 text-primary" />
+                    <dt className="w-24 shrink-0 text-text-body">定員</dt>
+                    <dd className="text-text-dark">
+                      {opportunity.capacity}名（現在{opportunity.current_applicants}
+                      名応募）
+                    </dd>
+                  </div>
+                )}
+                {opportunity.participation_mode && (
+                  <div className="flex items-center gap-3">
+                    <Globe className="size-4 shrink-0 text-primary" />
+                    <dt className="w-24 shrink-0 text-text-body">参加形態</dt>
+                    <dd className="text-text-dark">
+                      {PARTICIPATION_MODE_OPTIONS.find(
+                        (o) => o.value === opportunity.participation_mode
+                      )?.label ?? opportunity.participation_mode}
+                    </dd>
+                  </div>
+                )}
+                {opportunity.category && (
+                  <div className="flex items-center gap-3">
+                    <Tag className="size-4 shrink-0 text-primary" />
+                    <dt className="w-24 shrink-0 text-text-body">カテゴリ</dt>
+                    <dd className="text-text-dark">{opportunity.category}</dd>
+                  </div>
+                )}
+              </dl>
             </CardContent>
           </Card>
         )}

--- a/app/src/app/recommendations/components/RecommendationFilters.tsx
+++ b/app/src/app/recommendations/components/RecommendationFilters.tsx
@@ -5,17 +5,7 @@ import { Loader2, Search, X } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { type FormEvent, useState } from "react"
 import type { RecommendationFilters as RecommendationFiltersType } from "@/lib/recommendations/types"
-
-const CATEGORY_OPTIONS = [
-  "環境保全",
-  "地域活動",
-  "教育",
-  "子ども支援",
-  "居場所づくり",
-  "IT支援",
-  "高齢者支援",
-  "障がい者サポート",
-]
+import { CATEGORY_OPTIONS } from "@/lib/opportunities/constants"
 
 const REGION_OPTIONS = [
   "渋谷区",

--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -26,6 +26,11 @@ import type {
   RecommendedParticipantsResult,
 } from "./types";
 import { PERSONALITY_TYPES } from "@/lib/personality/constants";
+import {
+  isValidCategory,
+  isValidParticipationMode,
+  type ParticipationMode,
+} from "@/lib/opportunities/constants";
 
 /**
  * 団体ダッシュボード用：自団体の募集案件一覧を取得
@@ -287,6 +292,95 @@ const BIG5_TRAIT_KEYS = [
   "openness",
 ] as const;
 
+/** DATE カラムの値を YYYY-MM-DD に正規化する（ISO タイムスタンプにも対応） */
+function normalizeDateOnly(value: string | null): string | null {
+  if (!value) return null;
+  // "2026-06-19" や "2026-06-19T00:00:00.000Z" の先頭10文字を取り出す
+  return value.slice(0, 10);
+}
+
+/** YYYY-MM-DD 形式の日付文字列か判定する */
+function isValidDateString(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const time = Date.parse(value);
+  return !Number.isNaN(time);
+}
+
+/** 募集案件の追加項目（場所・日程・定員・カテゴリ・参加形態）のパース結果 */
+interface OpportunityExtraFields {
+  location: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  capacity: number | null;
+  category: string | null;
+  participation_mode: ParticipationMode | null;
+}
+
+/**
+ * FormData から募集案件の追加項目を取得・検証する。
+ * すべて任意項目だが、値がある場合は整合性を検証する。
+ * 検証エラー時は { error } を返す。
+ */
+function parseOpportunityExtraFields(
+  formData: FormData
+): { data: OpportunityExtraFields } | { error: string } {
+  const getTrimmed = (key: string): string => {
+    const raw = formData.get(key);
+    return typeof raw === "string" ? raw.trim() : "";
+  };
+
+  const location = getTrimmed("location");
+  const startDate = getTrimmed("startDate");
+  const endDate = getTrimmed("endDate");
+  const capacityRaw = getTrimmed("capacity");
+  const category = getTrimmed("category");
+  const participationMode = getTrimmed("participationMode");
+
+  // 日付の検証
+  if (startDate && !isValidDateString(startDate)) {
+    return { error: "開始日の形式が正しくありません" };
+  }
+  if (endDate && !isValidDateString(endDate)) {
+    return { error: "終了日の形式が正しくありません" };
+  }
+  if (startDate && endDate && endDate < startDate) {
+    return { error: "終了日は開始日以降の日付を指定してください" };
+  }
+
+  // 定員の検証
+  let capacity: number | null = null;
+  if (capacityRaw) {
+    const num = Number(capacityRaw);
+    if (!Number.isInteger(num) || num <= 0) {
+      return { error: "定員は1以上の整数で入力してください" };
+    }
+    capacity = num;
+  }
+
+  // カテゴリの検証
+  if (category && !isValidCategory(category)) {
+    return { error: "カテゴリの値が正しくありません" };
+  }
+
+  // 参加形態の検証
+  if (participationMode && !isValidParticipationMode(participationMode)) {
+    return { error: "参加形態の値が正しくありません" };
+  }
+
+  return {
+    data: {
+      location: location || null,
+      start_date: startDate || null,
+      end_date: endDate || null,
+      capacity,
+      category: category || null,
+      participation_mode: participationMode
+        ? (participationMode as ParticipationMode)
+        : null,
+    },
+  };
+}
+
 /**
  * 募集案件を新規作成する
  *
@@ -337,6 +431,12 @@ export async function createOpportunity(
     }
   }
 
+  // 追加項目（場所・日程・定員・カテゴリ・参加形態）の取得と検証
+  const extra = parseOpportunityExtraFields(formData);
+  if ("error" in extra) {
+    return { success: false, error: extra.error };
+  }
+
   try {
     // 団体プロフィールIDを取得
     const { data: orgProfile, error: profileError } = await supabase
@@ -358,6 +458,7 @@ export async function createOpportunity(
         requirement_traits:
           Object.keys(requiredTraits).length > 0 ? requiredTraits : null,
         status: "published",
+        ...extra.data,
       });
 
     if (insertError) {
@@ -428,7 +529,9 @@ export async function fetchOpportunityForEdit(
 
     const { data, error: fetchError } = await supabase
       .from("m_opportunity")
-      .select("id, title, description, requirement_traits, status")
+      .select(
+        "id, title, description, requirement_traits, status, location, start_date, end_date, capacity, category, participation_mode"
+      )
       .eq("id", id)
       .eq("organization_id", (orgProfile as unknown as { id: string }).id)
       .single();
@@ -437,13 +540,33 @@ export async function fetchOpportunityForEdit(
       return { opportunity: null };
     }
 
+    const row = data as unknown as {
+      id: string;
+      title: string;
+      description: string | null;
+      requirement_traits: Record<string, number> | null;
+      status: OpportunityStatus;
+      location: string | null;
+      start_date: string | null;
+      end_date: string | null;
+      capacity: number | null;
+      category: string | null;
+      participation_mode: ParticipationMode | null;
+    };
+
     const opportunity: OpportunityEditData = {
-      id: data.id as string,
-      title: data.title as string,
-      description: (data.description as string) ?? "",
-      required_traits:
-        ((data as unknown as { requirement_traits: Record<string, number> | null }).requirement_traits) ?? null,
-      status: data.status as OpportunityStatus,
+      id: row.id,
+      title: row.title,
+      description: row.description ?? "",
+      required_traits: row.requirement_traits ?? null,
+      status: row.status,
+      location: row.location ?? null,
+      // DATE カラムは YYYY-MM-DD 形式に正規化（<input type="date"> 用）
+      start_date: normalizeDateOnly(row.start_date),
+      end_date: normalizeDateOnly(row.end_date),
+      capacity: row.capacity ?? null,
+      category: row.category ?? null,
+      participation_mode: row.participation_mode ?? null,
     };
 
     return { opportunity };
@@ -508,6 +631,12 @@ export async function updateOpportunity(
     }
   }
 
+  // 追加項目（場所・日程・定員・カテゴリ・参加形態）の取得と検証
+  const extra = parseOpportunityExtraFields(formData);
+  if ("error" in extra) {
+    return { success: false, error: extra.error };
+  }
+
   try {
     // 団体プロフィールIDを取得
     const { data: orgProfile, error: profileError } = await supabase
@@ -525,6 +654,7 @@ export async function updateOpportunity(
       description,
       requirement_traits:
         Object.keys(requiredTraits).length > 0 ? requiredTraits : null,
+      ...extra.data,
     };
     if (status) {
       updateData.status = status;

--- a/app/src/lib/dashboard/create-opportunity.test.ts
+++ b/app/src/lib/dashboard/create-opportunity.test.ts
@@ -229,6 +229,126 @@ describe("createOpportunity", () => {
     expect(result.error).toBe("案件の作成に失敗しました");
   });
 
+  it("追加項目（場所・日程・定員・カテゴリ・参加形態）を保存できる", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    mockSingle.mockReturnValueOnce({ data: { id: "profile-123" }, error: null });
+    mockInsertReturn.mockReturnValueOnce({ error: null });
+
+    const fd = buildFormData({
+      title: "環境保全ボランティア",
+      description: "森林再生活動を行います",
+      location: "渋谷区",
+      startDate: "2026-07-01",
+      endDate: "2026-07-10",
+      capacity: "10",
+      category: "環境保全",
+      participationMode: "offline",
+    });
+
+    await createOpportunity(fd);
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "渋谷区",
+        start_date: "2026-07-01",
+        end_date: "2026-07-10",
+        capacity: 10,
+        category: "環境保全",
+        participation_mode: "offline",
+      })
+    );
+  });
+
+  it("追加項目が未入力の場合は null で保存される", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    mockSingle.mockReturnValueOnce({ data: { id: "profile-123" }, error: null });
+    mockInsertReturn.mockReturnValueOnce({ error: null });
+
+    const fd = buildFormData({ title: "テスト案件", description: "テスト説明" });
+
+    await createOpportunity(fd);
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: null,
+        start_date: null,
+        end_date: null,
+        capacity: null,
+        category: null,
+        participation_mode: null,
+      })
+    );
+  });
+
+  it("終了日が開始日より前の場合、バリデーションエラーを返す", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    const fd = buildFormData({
+      title: "テスト案件",
+      description: "テスト説明",
+      startDate: "2026-07-10",
+      endDate: "2026-07-01",
+    });
+
+    const result: CreateOpportunityResult = await createOpportunity(fd);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("終了日は開始日以降の日付を指定してください");
+  });
+
+  it("定員が0以下の場合、バリデーションエラーを返す", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    const fd = buildFormData({
+      title: "テスト案件",
+      description: "テスト説明",
+      capacity: "0",
+    });
+
+    const result: CreateOpportunityResult = await createOpportunity(fd);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("定員は1以上の整数で入力してください");
+  });
+
+  it("不正なカテゴリの場合、バリデーションエラーを返す", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    const fd = buildFormData({
+      title: "テスト案件",
+      description: "テスト説明",
+      category: "存在しないカテゴリ",
+    });
+
+    const result: CreateOpportunityResult = await createOpportunity(fd);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("カテゴリの値が正しくありません");
+  });
+
+  it("不正な参加形態の場合、バリデーションエラーを返す", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    const fd = buildFormData({
+      title: "テスト案件",
+      description: "テスト説明",
+      participationMode: "invalid",
+    });
+
+    const result: CreateOpportunityResult = await createOpportunity(fd);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("参加形態の値が正しくありません");
+  });
+
   it("予期しないエラー時もクラッシュせずエラーを返す", async () => {
     const mockUser = { id: "org-123", email: "org@example.com" };
     mockGetUser.mockReturnValue({

--- a/app/src/lib/dashboard/fetch-opportunity-edit.test.ts
+++ b/app/src/lib/dashboard/fetch-opportunity-edit.test.ts
@@ -166,6 +166,39 @@ describe("fetchOpportunityForEdit", () => {
     expect(result.opportunity?.description).toBe("");
   });
 
+  it("追加項目を取得し、日付を YYYY-MM-DD に正規化する", async () => {
+    const mockUser = { id: "user-123" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockReturnValueOnce({ data: { id: "profile-123" }, error: null });
+    mockSingle.mockReturnValueOnce({
+      data: {
+        id: "opp-3",
+        title: "テスト案件",
+        description: "説明",
+        requirement_traits: null,
+        status: "published",
+        location: "渋谷区",
+        // ISO タイムスタンプ形式でも正規化されること
+        start_date: "2026-07-01T00:00:00.000Z",
+        end_date: "2026-07-10",
+        capacity: 10,
+        category: "環境保全",
+        participation_mode: "offline",
+      },
+      error: null,
+    });
+
+    const result: OpportunityEditResult =
+      await fetchOpportunityForEdit("opp-3");
+
+    expect(result.opportunity?.location).toBe("渋谷区");
+    expect(result.opportunity?.start_date).toBe("2026-07-01");
+    expect(result.opportunity?.end_date).toBe("2026-07-10");
+    expect(result.opportunity?.capacity).toBe(10);
+    expect(result.opportunity?.category).toBe("環境保全");
+    expect(result.opportunity?.participation_mode).toBe("offline");
+  });
+
   it("DB エラー時もクラッシュせずエラーを返す", async () => {
     const mockUser = { id: "user-123" };
     mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });

--- a/app/src/lib/dashboard/types.ts
+++ b/app/src/lib/dashboard/types.ts
@@ -7,9 +7,12 @@
  */
 
 import type { RecommendedParticipant } from "./recommended-participants";
+import type { ParticipationMode } from "@/lib/opportunities/constants";
 
 /** 募集案件ステータス（DBスキーマ: draft / published / closed） */
 export type OpportunityStatus = "draft" | "published" | "closed";
+
+export type { ParticipationMode };
 
 /** 自団体の募集案件（応募者数付き） */
 export interface DashboardOpportunity {
@@ -38,6 +41,18 @@ export interface OpportunityEditData {
   description: string;
   required_traits: Record<string, number> | null;
   status: OpportunityStatus;
+  /** 活動場所 */
+  location: string | null;
+  /** 開始日（YYYY-MM-DD） */
+  start_date: string | null;
+  /** 終了日（YYYY-MM-DD） */
+  end_date: string | null;
+  /** 定員 */
+  capacity: number | null;
+  /** カテゴリ */
+  category: string | null;
+  /** 参加形態 */
+  participation_mode: ParticipationMode | null;
 }
 
 /** fetchOpportunityForEdit の戻り値 */

--- a/app/src/lib/dashboard/update-opportunity.test.ts
+++ b/app/src/lib/dashboard/update-opportunity.test.ts
@@ -203,6 +203,58 @@ describe("updateOpportunity", () => {
     );
   });
 
+  it("追加項目（場所・日程・定員・カテゴリ・参加形態）を更新できる", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    mockSingle.mockReturnValueOnce({ data: { id: "profile-123" }, error: null });
+    mockUpdateResult = { error: null };
+
+    const fd = buildFormData({
+      title: "更新された案件",
+      description: "更新された説明",
+      location: "新宿区",
+      startDate: "2026-08-01",
+      endDate: "2026-08-05",
+      capacity: "20",
+      category: "教育",
+      participationMode: "online",
+    });
+
+    await updateOpportunity("opp-1", fd);
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "新宿区",
+        start_date: "2026-08-01",
+        end_date: "2026-08-05",
+        capacity: 20,
+        category: "教育",
+        participation_mode: "online",
+      })
+    );
+  });
+
+  it("終了日が開始日より前の場合、バリデーションエラーを返す", async () => {
+    const mockUser = { id: "org-123", email: "org@example.com" };
+    mockGetUser.mockReturnValue({ data: { user: mockUser }, error: null });
+
+    const fd = buildFormData({
+      title: "テスト案件",
+      description: "テスト説明",
+      startDate: "2026-08-05",
+      endDate: "2026-08-01",
+    });
+
+    const result: UpdateOpportunityResult = await updateOpportunity(
+      "opp-1",
+      fd
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("終了日は開始日以降の日付を指定してください");
+  });
+
   it("ステータスが未指定の場合はステータスを更新しない", async () => {
     const mockUser = { id: "org-123", email: "org@example.com" };
     mockGetUser.mockReturnValue({

--- a/app/src/lib/opportunities/actions.test.ts
+++ b/app/src/lib/opportunities/actions.test.ts
@@ -109,6 +109,13 @@ describe("fetchOpportunityDetail", () => {
       requirement_traits: { extraversion: 70, agreeableness: 80 },
       status: "published",
       created_at: "2026-01-01T00:00:00Z",
+      location: "渋谷区",
+      start_date: "2026-07-01T00:00:00.000Z",
+      end_date: "2026-07-10",
+      capacity: 10,
+      current_applicants: 3,
+      category: "環境保全",
+      participation_mode: "offline",
       m_organization_profile: { id: "org-1", organization_name: "NPO法人テスト", description: "テスト団体です" },
     };
 
@@ -139,6 +146,14 @@ describe("fetchOpportunityDetail", () => {
     expect(result.opportunity?.description).toBe("森林保全活動です");
     expect(result.opportunity?.organization.name).toBe("NPO法人テスト");
     expect(result.opportunity?.status).toBe("published");
+    // 追加項目（日付は YYYY-MM-DD に正規化される）
+    expect(result.opportunity?.location).toBe("渋谷区");
+    expect(result.opportunity?.start_date).toBe("2026-07-01");
+    expect(result.opportunity?.end_date).toBe("2026-07-10");
+    expect(result.opportunity?.capacity).toBe(10);
+    expect(result.opportunity?.current_applicants).toBe(3);
+    expect(result.opportunity?.category).toBe("環境保全");
+    expect(result.opportunity?.participation_mode).toBe("offline");
     expect(result.isParticipant).toBe(true);
     expect(result.matchScore).toBe(75); // モックされた calculateMatchScore の戻り値
     expect(result.existingApplication).toBeNull();

--- a/app/src/lib/opportunities/actions.ts
+++ b/app/src/lib/opportunities/actions.ts
@@ -78,6 +78,13 @@ export async function fetchOpportunityDetail(
         requirement_traits,
         status,
         created_at,
+        location,
+        start_date,
+        end_date,
+        capacity,
+        current_applicants,
+        category,
+        participation_mode,
         m_organization_profile (
           id,
           organization_name,
@@ -117,6 +124,17 @@ export async function fetchOpportunityDetail(
         description: org?.description ?? null,
       },
       created_at: oppData.created_at as string,
+      location: (oppData.location as string | null) ?? null,
+      start_date:
+        ((oppData.start_date as string | null) ?? null)?.slice(0, 10) ?? null,
+      end_date:
+        ((oppData.end_date as string | null) ?? null)?.slice(0, 10) ?? null,
+      capacity: (oppData.capacity as number | null) ?? null,
+      current_applicants: (oppData.current_applicants as number | null) ?? 0,
+      category: (oppData.category as string | null) ?? null,
+      participation_mode:
+        (oppData.participation_mode as OpportunityDetail["participation_mode"]) ??
+        null,
     };
 
     // 参加者プロフィールを取得（マッチングスコア計算用）

--- a/app/src/lib/opportunities/constants.ts
+++ b/app/src/lib/opportunities/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * 募集案件の選択肢定数
+ *
+ * 作成・編集フォーム、おすすめフィルタ、Server Action の validation で共用する。
+ * フォームとフィルタの選択肢を一致させ、案件レベルのデータ整合性を保つ。
+ */
+
+/** 参加形態（DB enum: participation_mode に対応） */
+export type ParticipationMode = "online" | "offline" | "hybrid";
+
+/** カテゴリの選択肢 */
+export const CATEGORY_OPTIONS = [
+  "環境保全",
+  "地域活動",
+  "教育",
+  "子ども支援",
+  "居場所づくり",
+  "IT支援",
+  "高齢者支援",
+  "障がい者サポート",
+] as const;
+
+/** 参加形態の選択肢（value と日本語ラベル） */
+export const PARTICIPATION_MODE_OPTIONS = [
+  { value: "online", label: "オンライン" },
+  { value: "offline", label: "オフライン（対面）" },
+  { value: "hybrid", label: "ハイブリッド" },
+] as const;
+
+/** 値が有効なカテゴリか判定する */
+export function isValidCategory(value: string): boolean {
+  return (CATEGORY_OPTIONS as readonly string[]).includes(value);
+}
+
+/** 値が有効な参加形態か判定する */
+export function isValidParticipationMode(
+  value: string
+): value is ParticipationMode {
+  return value === "online" || value === "offline" || value === "hybrid";
+}

--- a/app/src/lib/opportunities/types.ts
+++ b/app/src/lib/opportunities/types.ts
@@ -7,6 +7,8 @@
  * - applications: 応募情報
  */
 
+import type { ParticipationMode } from "@/lib/opportunities/constants";
+
 /** 案件ステータス（DBスキーマ: draft / published / closed） */
 export type OpportunityStatus = "draft" | "published" | "closed";
 
@@ -29,6 +31,20 @@ export interface OpportunityDetail {
   status: OpportunityStatus;
   organization: OrganizationInfo;
   created_at: string;
+  /** 活動場所 */
+  location: string | null;
+  /** 開始日（YYYY-MM-DD） */
+  start_date: string | null;
+  /** 終了日（YYYY-MM-DD） */
+  end_date: string | null;
+  /** 定員 */
+  capacity: number | null;
+  /** 現在の応募者数 */
+  current_applicants: number;
+  /** カテゴリ */
+  category: string | null;
+  /** 参加形態 */
+  participation_mode: ParticipationMode | null;
 }
 
 /** 既存の応募情報 */

--- a/app/src/lib/recommendations/actions.test.ts
+++ b/app/src/lib/recommendations/actions.test.ts
@@ -40,9 +40,10 @@ type MockOpportunity = {
   description: string | null
   requirementTraits: Record<string, number> | null
   location: string | null
+  category: string | null
+  participationMode: "online" | "offline" | "hybrid" | null
   organization: {
     organizationName: string
-    activityCategories: string[] | null
     activityAreas: string[] | null
   }
 }
@@ -57,9 +58,10 @@ function createOpportunity({
     description: null,
     requirementTraits: { extraversion: 50 },
     location: "東京都渋谷区",
+    category: "環境保全",
+    participationMode: "offline",
     organization: {
       organizationName: `${id} 団体`,
-      activityCategories: ["環境保全"],
       activityAreas: ["渋谷区"],
     },
     ...overrides,
@@ -73,24 +75,10 @@ describe("fetchRecommendations", () => {
     mockFindParticipant.mockResolvedValue({ diagnosisScores })
   })
 
-  it("category が指定された場合、団体の活動カテゴリに一致する案件だけを返す", async () => {
+  it("category が指定された場合、案件のカテゴリに一致する案件だけを返す", async () => {
     mockFindOpportunities.mockResolvedValue([
-      createOpportunity({
-        id: "env-1",
-        organization: {
-          organizationName: "環境団体",
-          activityCategories: ["環境保全", "地域活動"],
-          activityAreas: ["渋谷区"],
-        },
-      }),
-      createOpportunity({
-        id: "edu-1",
-        organization: {
-          organizationName: "教育団体",
-          activityCategories: ["教育"],
-          activityAreas: ["渋谷区"],
-        },
-      }),
+      createOpportunity({ id: "env-1", category: "環境保全" }),
+      createOpportunity({ id: "edu-1", category: "教育" }),
     ])
 
     const result = await fetchRecommendations({ category: "環境保全" })
@@ -107,7 +95,6 @@ describe("fetchRecommendations", () => {
         location: "神奈川県横浜市",
         organization: {
           organizationName: "地域団体",
-          activityCategories: ["地域活動"],
           activityAreas: ["東京都渋谷区"],
         },
       }),
@@ -117,7 +104,6 @@ describe("fetchRecommendations", () => {
         location: "東京都渋谷区",
         organization: {
           organizationName: "場所一致団体",
-          activityCategories: ["地域活動"],
           activityAreas: ["世田谷区"],
         },
       }),
@@ -126,7 +112,6 @@ describe("fetchRecommendations", () => {
         location: "大阪府大阪市",
         organization: {
           organizationName: "対象外団体",
-          activityCategories: ["地域活動"],
           activityAreas: ["大阪府"],
         },
       }),
@@ -144,26 +129,26 @@ describe("fetchRecommendations", () => {
     mockFindOpportunities.mockResolvedValue([
       createOpportunity({
         id: "both-match",
+        category: "環境保全",
         organization: {
           organizationName: "両方一致団体",
-          activityCategories: ["環境保全"],
           activityAreas: ["渋谷区"],
         },
       }),
       createOpportunity({
         id: "category-only",
+        category: "環境保全",
         location: "大阪府大阪市",
         organization: {
           organizationName: "カテゴリのみ団体",
-          activityCategories: ["環境保全"],
           activityAreas: ["大阪府"],
         },
       }),
       createOpportunity({
         id: "region-only",
+        category: "教育",
         organization: {
           organizationName: "地域のみ団体",
-          activityCategories: ["教育"],
           activityAreas: ["渋谷区"],
         },
       }),
@@ -179,91 +164,43 @@ describe("fetchRecommendations", () => {
     ])
   })
 
-  it("participationMode が online の場合、オンラインまたはリモートの案件だけを返す", async () => {
+  it("participationMode が online の場合、参加形態が online の案件だけを返す", async () => {
     mockFindOpportunities.mockResolvedValue([
-      createOpportunity({
-        id: "online-location",
-        location: "オンライン",
-        organization: {
-          organizationName: "オンライン団体",
-          activityCategories: ["IT支援"],
-          activityAreas: ["全国"],
-        },
-      }),
-      createOpportunity({
-        id: "remote-area",
-        location: "東京都渋谷区",
-        organization: {
-          organizationName: "リモート団体",
-          activityCategories: ["IT支援"],
-          activityAreas: ["リモート"],
-        },
-      }),
-      createOpportunity({
-        id: "offline",
-        location: "東京都練馬区",
-        organization: {
-          organizationName: "対面団体",
-          activityCategories: ["地域活動"],
-          activityAreas: ["練馬区"],
-        },
-      }),
+      createOpportunity({ id: "online-1", participationMode: "online" }),
+      createOpportunity({ id: "offline-1", participationMode: "offline" }),
     ])
 
     const result = await fetchRecommendations({ participationMode: "online" })
 
-    expect(result.recommendations.map((item) => item.id)).toEqual([
-      "online-location",
-      "remote-area",
-    ])
+    expect(result.recommendations.map((item) => item.id)).toEqual(["online-1"])
   })
 
-  it("participationMode が offline の場合、オンラインまたはリモートを含まない案件だけを返す", async () => {
+  it("participationMode が offline の場合、参加形態が offline の案件だけを返す", async () => {
     mockFindOpportunities.mockResolvedValue([
-      createOpportunity({
-        id: "online-location",
-        location: "オンライン",
-        organization: {
-          organizationName: "オンライン団体",
-          activityCategories: ["IT支援"],
-          activityAreas: ["全国"],
-        },
-      }),
-      createOpportunity({
-        id: "remote-area",
-        location: "東京都渋谷区",
-        organization: {
-          organizationName: "リモート団体",
-          activityCategories: ["IT支援"],
-          activityAreas: ["リモート"],
-        },
-      }),
-      createOpportunity({
-        id: "offline",
-        location: "東京都練馬区",
-        organization: {
-          organizationName: "対面団体",
-          activityCategories: ["地域活動"],
-          activityAreas: ["練馬区"],
-        },
-      }),
+      createOpportunity({ id: "online-1", participationMode: "online" }),
+      createOpportunity({ id: "offline-1", participationMode: "offline" }),
     ])
 
     const result = await fetchRecommendations({ participationMode: "offline" })
 
-    expect(result.recommendations.map((item) => item.id)).toEqual(["offline"])
+    expect(result.recommendations.map((item) => item.id)).toEqual(["offline-1"])
+  })
+
+  it("hybrid の案件は online/offline 両方のフィルタに合致する", async () => {
+    mockFindOpportunities.mockResolvedValue([
+      createOpportunity({ id: "hybrid-1", participationMode: "hybrid" }),
+    ])
+
+    const online = await fetchRecommendations({ participationMode: "online" })
+    const offline = await fetchRecommendations({ participationMode: "offline" })
+
+    expect(online.recommendations.map((item) => item.id)).toEqual(["hybrid-1"])
+    expect(offline.recommendations.map((item) => item.id)).toEqual(["hybrid-1"])
   })
 
   it("フィルタ後に該当案件がない場合、診断済みの空結果を返す", async () => {
     mockFindOpportunities.mockResolvedValue([
-      createOpportunity({
-        id: "edu-1",
-        organization: {
-          organizationName: "教育団体",
-          activityCategories: ["教育"],
-          activityAreas: ["渋谷区"],
-        },
-      }),
+      createOpportunity({ id: "edu-1", category: "教育" }),
     ])
 
     const result = await fetchRecommendations({ category: "環境保全" })

--- a/app/src/lib/recommendations/actions.ts
+++ b/app/src/lib/recommendations/actions.ts
@@ -18,8 +18,6 @@ const BIG5_TRAIT_KEYS = [
   "openness",
 ] as const
 
-const ONLINE_KEYWORDS = ["オンライン", "リモート"] as const
-
 /**
  * 未知の値が BIG5Scores 型かどうかを実行時に検証するタイプガード
  */
@@ -54,8 +52,8 @@ function toStringArray(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === "string")
 }
 
-function matchesCategory(value: unknown, category: string): boolean {
-  return toStringArray(value).some((item) => item === category)
+function matchesCategory(category: string | null, filter: string): boolean {
+  return category === filter
 }
 
 function matchesRegion(
@@ -76,26 +74,13 @@ function normalizeParticipationMode(
   return value === "online" || value === "offline" ? value : null
 }
 
-function isOnlineOpportunity(
-  location: string | null,
-  activityAreas: unknown
-): boolean {
-  const values = [
-    ...(location ? [location] : []),
-    ...toStringArray(activityAreas),
-  ]
-  return values.some((value) =>
-    ONLINE_KEYWORDS.some((keyword) => value.includes(keyword))
-  )
-}
-
 function matchesParticipationMode(
-  location: string | null,
-  activityAreas: unknown,
-  participationMode: NonNullable<RecommendationFilters["participationMode"]>
+  participationMode: string | null,
+  filter: NonNullable<RecommendationFilters["participationMode"]>
 ): boolean {
-  const online = isOnlineOpportunity(location, activityAreas)
-  return participationMode === "online" ? online : !online
+  // hybrid 案件は online/offline 両方のフィルタに合致する
+  if (participationMode === "hybrid") return true
+  return participationMode === filter
 }
 
 /**
@@ -145,11 +130,12 @@ export async function fetchRecommendations(
         title: true,
         description: true,
         location: true,
+        category: true,
+        participationMode: true,
         requirementTraits: true,
         organization: {
           select: {
             organizationName: true,
-            activityCategories: true,
             activityAreas: true,
           },
         },
@@ -161,10 +147,7 @@ export async function fetchRecommendations(
     }
 
     const filteredOpportunities = opportunities.filter((opp) => {
-      if (
-        categoryFilter &&
-        !matchesCategory(opp.organization.activityCategories, categoryFilter)
-      ) {
+      if (categoryFilter && !matchesCategory(opp.category, categoryFilter)) {
         return false
       }
 
@@ -181,11 +164,7 @@ export async function fetchRecommendations(
 
       if (
         participationModeFilter &&
-        !matchesParticipationMode(
-          opp.location,
-          opp.organization.activityAreas,
-          participationModeFilter
-        )
+        !matchesParticipationMode(opp.participationMode, participationModeFilter)
       ) {
         return false
       }


### PR DESCRIPTION
Closes #114

## Summary

- **スキーマ**: `ParticipationMode` enum (`online`/`offline`/`hybrid`) を追加。`Opportunity` に `category`・`participation_mode` カラムを追加（migration: NULL 許可で既存データに安全適用）
- **共有定数**: `lib/opportunities/constants.ts` を新設。カテゴリ・参加形態の選択肢をフォーム・フィルタ・Action で共用
- **作成・編集フォーム**: 場所・開始日・終了日・定員・カテゴリ・参加形態の入力欄を追加（任意、編集時はプリフィル）
- **Server Action**: `createOpportunity` / `updateOpportunity` に新項目の取得・整合性 validation（終了日≥開始日、定員>0、カテゴリ/参加形態値検証）・保存を追加。`fetchOpportunityForEdit` も新項目を返すよう拡張
- **案件詳細表示**: 「募集情報」セクションを追加（場所/開催期間/定員（現在応募数併記）/参加形態/カテゴリ、null 項目は非表示）
- **おすすめフィルタ刷新**: カテゴリ・参加形態を団体レベル代用判定（`activityCategories`・location 文字列推測）から**案件レベルの構造化データ判定**に統一（`hybrid` 案件は online/offline 両フィルタに合致）

## 受け入れ条件チェック

- [x] 団体が MVP で必要な募集項目を入力できる
- [x] 入力値が DB に保存される
- [x] 案件編集時に既存値が表示・更新できる
- [x] 参加者向け案件詳細に場所・日程・定員・参加形態などが表示される
- [x] おすすめ案件一覧のフィルタと DB の値が整合している
- [x] 必須項目の validation がある
- [x] 既存データに対して migration が安全に適用できる（全カラム NULL 許可）

## Test plan

- [ ] `npm run test` で 264 件すべてパスすること（ローカル確認済み）
- [ ] `npm run lint` でエラーなし（確認済み）
- [ ] `npm run build` が成功すること（確認済み）
- [ ] ダッシュボードで募集案件を新規作成（全項目入力）→ DB に保存されること
- [ ] 案件編集画面で場所・日程・定員・カテゴリ・参加形態が既存値でプリフィルされ更新できること
- [ ] `/opportunities/:id` 詳細ページに「募集情報」セクションが表示されること
- [ ] `/recommendations` でカテゴリ・参加形態・地域フィルタが案件レベル値で正しく絞り込まれること
- [ ] migration を `prisma migrate deploy`（または `migrate dev`）で適用できること

## 補足

- `必要スキル` は issue に「必要スキルまたは求める特性」と記載されており、既存の `requirementTraits`（BIG5）で充足するため別途追加していません
- テスト実行環境の rollup ネイティブ依存不整合（node x64/Rosetta vs arm64 インストール）は `--no-save` で回避済み（package.json は未変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)