### PR TITLE
feat: 404ページを実装する

### DIFF
--- a/app/src/app/not-found.test.tsx
+++ b/app/src/app/not-found.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import NotFound from "./not-found";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/components/Header", () => ({
+  Header: () => <header>ヘッダー</header>,
+}));
+
+describe("NotFound", () => {
+  it("404メッセージと主要導線を表示する", () => {
+    render(<NotFound />);
+
+    expect(
+      screen.getByRole("heading", { name: "ページが見つかりません" }),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "削除された、URLが変更された、または入力したURLが間違っている可能性があります。",
+      ),
+    ).toBeDefined();
+
+    expect(screen.getByText("ヘッダー")).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: /トップへ戻る/ }).getAttribute("href"),
+    ).toBe("/");
+    expect(
+      screen.getByRole("link", { name: /診断を始める/ }).getAttribute("href"),
+    ).toBe("/diagnosis?mode=brief");
+  });
+
+  it("CTAをモバイルでは縦積み、広い画面では横並びにする", () => {
+    const { container } = render(<NotFound />);
+
+    const actions = container.querySelector("[data-testid='not-found-actions']");
+
+    expect(actions?.className).toContain("flex-col");
+    expect(actions?.className).toContain("sm:flex-row");
+  });
+});

--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { Home, SearchX, Sparkles } from "lucide-react";
+import { Header } from "@/app/components/Header";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+      <main className="mx-auto flex max-w-3xl flex-col items-center px-6 py-16 text-center sm:py-20">
+        <div className="flex size-16 items-center justify-center rounded-full bg-primary/10">
+          <SearchX className="size-8 text-primary" aria-hidden />
+        </div>
+
+        <p className="mt-6 text-sm font-semibold text-primary">
+          エラーコード 404
+        </p>
+
+        <h1 className="mt-3 text-3xl font-bold text-text-dark sm:text-4xl">
+          ページが見つかりません
+        </h1>
+
+        <p className="mt-4 max-w-xl text-sm leading-6 text-text-body sm:text-base sm:leading-7">
+          削除された、URLが変更された、または入力したURLが間違っている可能性があります。
+        </p>
+
+        <div
+          data-testid="not-found-actions"
+          className="mt-8 flex flex-col gap-3 sm:flex-row"
+        >
+          <Link
+            href="/"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-card-border bg-background px-4 text-sm font-medium text-text-dark transition-colors hover:bg-primary/5"
+          >
+            <Home className="size-4" aria-hidden />
+            トップへ戻る
+          </Link>
+          <Link
+            href="/diagnosis?mode=brief"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-white transition-colors hover:bg-primary-dark"
+          >
+            <Sparkles className="size-4" aria-hidden />
+            診断を始める
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { proxy } from "./proxy";
+
+const mocks = vi.hoisted(() => ({
+  updateSession: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/middleware", () => ({
+  updateSession: mocks.updateSession,
+}));
+
+function createRequest(pathname: string): NextRequest {
+  return new NextRequest(new URL(pathname, "http://localhost:3000"));
+}
+
+function mockGuestSession(request: NextRequest) {
+  mocks.updateSession.mockResolvedValue({
+    response: NextResponse.next({ request }),
+    user: null,
+  });
+}
+
+describe("proxy", () => {
+  beforeEach(() => {
+    mocks.updateSession.mockReset();
+  });
+
+  it("未認証の未知URLはログインへ送らず404判定へ通す", async () => {
+    const request = createRequest("/missing-page");
+    mockGuestSession(request);
+
+    const response = await proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("未認証の保護ルートはログインへリダイレクトする", async () => {
+    const request = createRequest("/dashboard");
+    mockGuestSession(request);
+
+    const response = await proxy(request);
+    const location = new URL(
+      response.headers.get("location") ?? "",
+      request.url,
+    );
+
+    expect(response.status).toBe(307);
+    expect(location.pathname).toBe("/login");
+    expect(location.searchParams.get("next")).toBe("/dashboard");
+  });
+});

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -17,9 +17,28 @@ const AUTH_CALLBACK = "/auth/callback";
 /** パブリックルート（認証不要、リダイレクトなし） */
 const PUBLIC_PATHS = new Set(["/"]);
 
+/** 認証必須ルートの prefix */
+const PROTECTED_PATH_PREFIXES = [
+  "/admin",
+  "/dashboard",
+  "/diagnosis",
+  "/mypage",
+  "/onboarding",
+  "/opportunities",
+  "/organizations",
+  "/recommendations",
+];
+
 /** 認証系パス（ログイン済みなら / へリダイレクト） */
 function isAuthPath(pathname: string): boolean {
   return pathname === "/login" || pathname.startsWith("/signup");
+}
+
+/** 認証必須ルートかどうか */
+function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
 }
 
 /** オンボーディングパス（認証必須だがプロフィールチェック不要） */
@@ -64,11 +83,17 @@ export async function proxy(request: NextRequest) {
   }
 
   // --- パブリック（/）: 未認証ならスルー、認証済みならロール/オンボーディングチェックを実施 ---
-  if (PUBLIC_PATHS.has(pathname)) {
+  const isPublicPath = PUBLIC_PATHS.has(pathname);
+  if (isPublicPath) {
     if (!user) {
       return response;
     }
     // 認証済みユーザーは下のロール・オンボーディングチェックに進む
+  }
+
+  // --- 保護対象外の未知URLなどは Next.js の 404 判定へ通す ---
+  if (!isPublicPath && !isProtectedPath(pathname)) {
+    return response;
   }
 
   // --- 以下は認証必須 ---


### PR DESCRIPTION
## 概要
- Next.js App Router の `app/src/app/not-found.tsx` を追加
- 未認証の未知 URL がログインへリダイレクトされず 404 ページへ到達するよう proxy を調整
- 404 ページ本体と proxy 分岐のテストを追加

## 背景
Issue #127 の S-04「404ページ」対応です。既存 proxy は保護対象外の未知 URL も未認証時に `/login?next=...` へ送っていたため、404 ページを追加しても存在しない URL で表示されませんでした。

Closes #127

## 確認
- `npx vitest run src/app/not-found.test.tsx src/proxy.test.ts`
- `npm run test`
- `npm run lint`（既存 warning: `src/lib/dashboard/update-opportunity.test.ts` の `_args` 未使用）
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres npm run build`
- `curl http://localhost:3000/__codex-not-found-after-main` で `status=404` と 404 文言を確認
