### PR TITLE
[codex] マッチング履歴画面を追加

### DIFF
--- a/app/src/app/dashboard/history/page.tsx
+++ b/app/src/app/dashboard/history/page.tsx
@@ -1,0 +1,186 @@
+import Link from "next/link";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  History,
+  SearchX,
+  Sparkles,
+  User,
+  XCircle,
+} from "lucide-react";
+import { redirect } from "next/navigation";
+import { Header } from "@/app/components/Header";
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import { fetchMatchingHistory } from "@/lib/dashboard/actions";
+import type {
+  MatchingHistoryItem,
+  MatchingHistoryStatus,
+} from "@/lib/dashboard/types";
+
+export const dynamic = "force-dynamic";
+
+function statusDisplay(status: MatchingHistoryStatus) {
+  switch (status) {
+    case "approved":
+      return {
+        label: "承認済み",
+        icon: <CheckCircle2 className="size-4" />,
+        color: "text-green-700 bg-green-50 border-green-200",
+      };
+    case "rejected":
+      return {
+        label: "辞退済み",
+        icon: <XCircle className="size-4" />,
+        color: "text-red-700 bg-red-50 border-red-200",
+      };
+  }
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "未記録";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "未記録";
+
+  return date.toLocaleString("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function MatchingHistoryCard({ item }: { item: MatchingHistoryItem }) {
+  const display = statusDisplay(item.status);
+
+  return (
+    <Card>
+      <CardContent>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+              <User className="size-5 text-primary" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-text-dark">
+                {item.participant_name}
+              </h2>
+              <p className="mt-1 text-sm text-text-body">
+                {item.opportunity_title}
+              </p>
+            </div>
+          </div>
+          <span
+            className={`inline-flex w-fit items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium ${display.color}`}
+          >
+            {display.icon}
+            {display.label}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-4 text-xs text-text-body">
+          <span className="inline-flex items-center gap-1">
+            <Clock className="size-3.5" />
+            処理日時: {formatDateTime(item.status_changed_at)}
+          </span>
+          <span>応募日時: {formatDateTime(item.applied_at)}</span>
+          {item.match_score !== null && (
+            <span className="inline-flex items-center gap-1">
+              <Sparkles className="size-3.5 text-primary" />
+              相性スコア: {Math.round(item.match_score)}%
+            </span>
+          )}
+        </div>
+
+        <Link
+          href={`/dashboard/opportunities/${item.opportunity_id}/applicants/${item.id}`}
+          className="inline-flex w-fit items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          応募詳細を見る
+          <ChevronRight className="size-4" />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function DashboardHistoryPage() {
+  const { history, error } = await fetchMatchingHistory();
+
+  if (error === "ログインが必要です") {
+    redirect("/login");
+  }
+  if (error === "団体アカウントのみ利用できます") {
+    redirect("/onboarding/role");
+  }
+  if (error === "団体プロフィールが見つかりません") {
+    redirect("/onboarding/organization");
+  }
+  if (error === "承認済み団体のみ利用できます") {
+    redirect("/onboarding/pending");
+  }
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+
+      <main className="mx-auto max-w-4xl px-6 py-8">
+        <Link
+          href="/dashboard"
+          className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          ダッシュボードに戻る
+        </Link>
+
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-text-dark">
+            マッチング履歴
+          </h1>
+          <p className="mt-2 text-sm text-text-body">
+            過去に承認・辞退した応募の履歴を確認できます。
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-lg border border-card-border bg-white p-4 text-sm text-text-body">
+            {error}
+          </div>
+        )}
+
+        {history.length > 0 ? (
+          <div className="space-y-4">
+            {history.map((item) => (
+              <MatchingHistoryCard key={item.id} item={item} />
+            ))}
+          </div>
+        ) : (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+                  <SearchX className="size-5 text-primary" />
+                </div>
+                <h2 className="text-lg font-bold text-text-dark">
+                  承認・辞退済みの応募はまだありません
+                </h2>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm leading-6 text-text-body">
+                応募者一覧で承認または辞退した応募が、ここに履歴として表示されます。
+              </p>
+              <Link
+                href="/dashboard"
+                className="inline-flex w-fit items-center gap-2 text-sm font-medium text-primary hover:underline"
+              >
+                <History className="size-4" />
+                募集案件を確認する
+              </Link>
+            </CardContent>
+          </Card>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   MessageSquarePlus,
   X,
   FileCheck2,
+  History,
 } from "lucide-react";
 import { redirect } from "next/navigation";
 import { Header } from "@/app/components/Header";
@@ -175,6 +176,13 @@ export default async function DashboardPage() {
             >
               <MessageSquarePlus className="size-4" />
               アプローチ履歴
+            </Link>
+            <Link
+              href="/dashboard/history"
+              className="inline-flex items-center gap-2 rounded-lg border border-card-border bg-white px-4 py-2 text-sm font-medium text-text-dark shadow-sm transition-colors hover:bg-primary/5"
+            >
+              <History className="size-4" />
+              マッチング履歴
             </Link>
             <Link
               href="/dashboard/certificates"

--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -22,6 +22,8 @@ import type {
   ApplicantsResult,
   UpdateApplicationStatusResult,
   ApplicantDetailResult,
+  MatchingHistoryResult,
+  MatchingHistoryStatus,
   RecommendedParticipantDetailResult,
   RecommendedParticipantsResult,
 } from "./types";
@@ -841,6 +843,116 @@ function mapApplicationStatus(dbStatus: string): Applicant["status"] {
   if (dbStatus === "completed") return "completed";
   if (dbStatus === "declined") return "rejected";
   return "pending";
+}
+
+function mapMatchingHistoryStatus(
+  dbStatus: string
+): MatchingHistoryStatus | null {
+  if (dbStatus === "accepted") return "approved";
+  if (dbStatus === "declined") return "rejected";
+  return null;
+}
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function toNullableIsoString(value: Date | string | null): string | null {
+  return value ? toIsoString(value) : null;
+}
+
+/**
+ * 団体向けマッチング履歴を取得する。
+ *
+ * 自団体の応募のうち、承認・辞退済みのものだけを処理日時順で返す。
+ */
+export async function fetchMatchingHistory(): Promise<MatchingHistoryResult> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { history: [], error: "ログインが必要です" };
+    }
+
+    const organizationProfile = await prisma.organizationProfile.findUnique({
+      where: { userId: user.id },
+      select: {
+        id: true,
+        reviewStatus: true,
+        user: { select: { role: true } },
+      },
+    });
+
+    if (!organizationProfile) {
+      return { history: [], error: "団体プロフィールが見つかりません" };
+    }
+
+    if (organizationProfile.user.role !== "organization") {
+      return { history: [], error: "団体アカウントのみ利用できます" };
+    }
+
+    if (organizationProfile.reviewStatus !== "approved") {
+      return { history: [], error: "承認済み団体のみ利用できます" };
+    }
+
+    const records = await prisma.matchingCandidate.findMany({
+      where: {
+        status: { in: ["accepted", "declined"] },
+        opportunity: { organizationId: organizationProfile.id },
+      },
+      select: {
+        id: true,
+        status: true,
+        appliedAt: true,
+        statusChangedAt: true,
+        matchScore: true,
+        participant: {
+          select: {
+            name: true,
+            participantProfile: { select: { name: true } },
+          },
+        },
+        opportunity: {
+          select: { id: true, title: true },
+        },
+      },
+      orderBy: [
+        { statusChangedAt: "desc" },
+        { appliedAt: "desc" },
+        { id: "asc" },
+      ],
+    });
+
+    const history = records.flatMap((record) => {
+      const status = mapMatchingHistoryStatus(record.status);
+      if (!status) return [];
+
+      return [
+        {
+          id: record.id,
+          status,
+          participant_name:
+            record.participant.participantProfile?.name ??
+            record.participant.name ??
+            "不明",
+          opportunity_id: record.opportunity.id,
+          opportunity_title: record.opportunity.title,
+          applied_at: toNullableIsoString(record.appliedAt),
+          status_changed_at: toIsoString(record.statusChangedAt),
+          match_score: record.matchScore,
+        },
+      ];
+    });
+
+    return { history };
+  } catch (err) {
+    console.error("[fetchMatchingHistory] 予期しないエラー:", err);
+    return { history: [], error: "予期しないエラーが発生しました" };
+  }
 }
 
 /**

--- a/app/src/lib/dashboard/matching-history.test.ts
+++ b/app/src/lib/dashboard/matching-history.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+const mockFindOrganizationProfile = vi.fn();
+const mockFindMatchingCandidates = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mockGetUser(),
+    },
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    organizationProfile: {
+      findUnique: (...args: unknown[]) => mockFindOrganizationProfile(...args),
+    },
+    matchingCandidate: {
+      findMany: (...args: unknown[]) => mockFindMatchingCandidates(...args),
+    },
+  },
+}));
+
+const { fetchMatchingHistory } = await import("./actions");
+
+const approvedOrganization = {
+  id: "org-profile-1",
+  reviewStatus: "approved",
+  user: { role: "organization" },
+};
+
+describe("fetchMatchingHistory", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetUser.mockReturnValue({
+      data: { user: { id: "organization-user-1" } },
+      error: null,
+    });
+    mockFindOrganizationProfile.mockResolvedValue(approvedOrganization);
+    mockFindMatchingCandidates.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("未ログインの場合はエラーを返す", async () => {
+    mockGetUser.mockReturnValue({
+      data: { user: null },
+      error: { message: "ログインしていません" },
+    });
+
+    const result = await fetchMatchingHistory();
+
+    expect(result.history).toEqual([]);
+    expect(result.error).toBe("ログインが必要です");
+    expect(mockFindOrganizationProfile).not.toHaveBeenCalled();
+  });
+
+  it("団体プロフィールがない場合はエラーを返す", async () => {
+    mockFindOrganizationProfile.mockResolvedValue(null);
+
+    const result = await fetchMatchingHistory();
+
+    expect(result.history).toEqual([]);
+    expect(result.error).toBe("団体プロフィールが見つかりません");
+  });
+
+  it("団体ロール以外の場合はエラーを返す", async () => {
+    mockFindOrganizationProfile.mockResolvedValue({
+      ...approvedOrganization,
+      user: { role: "participant" },
+    });
+
+    const result = await fetchMatchingHistory();
+
+    expect(result.history).toEqual([]);
+    expect(result.error).toBe("団体アカウントのみ利用できます");
+    expect(mockFindMatchingCandidates).not.toHaveBeenCalled();
+  });
+
+  it("未承認団体の場合はエラーを返す", async () => {
+    mockFindOrganizationProfile.mockResolvedValue({
+      ...approvedOrganization,
+      reviewStatus: "pending",
+    });
+
+    const result = await fetchMatchingHistory();
+
+    expect(result.history).toEqual([]);
+    expect(result.error).toBe("承認済み団体のみ利用できます");
+    expect(mockFindMatchingCandidates).not.toHaveBeenCalled();
+  });
+
+  it("自団体の承認・辞退済み応募を処理日時順で返す", async () => {
+    mockFindMatchingCandidates.mockResolvedValue([
+      {
+        id: "application-accepted",
+        status: "accepted",
+        appliedAt: new Date("2026-06-01T09:00:00.000Z"),
+        statusChangedAt: new Date("2026-06-10T12:30:00.000Z"),
+        matchScore: 87.4,
+        participant: {
+          name: "ユーザー名フォールバック",
+          participantProfile: { name: "山田 花子" },
+        },
+        opportunity: {
+          id: "opportunity-1",
+          title: "地域清掃ボランティア",
+        },
+      },
+      {
+        id: "application-declined",
+        status: "declined",
+        appliedAt: null,
+        statusChangedAt: new Date("2026-06-09T08:15:00.000Z"),
+        matchScore: null,
+        participant: {
+          name: "佐藤 太郎",
+          participantProfile: null,
+        },
+        opportunity: {
+          id: "opportunity-2",
+          title: "学習支援スタッフ",
+        },
+      },
+    ]);
+
+    const result = await fetchMatchingHistory();
+
+    expect(result.error).toBeUndefined();
+    expect(result.history).toEqual([
+      {
+        id: "application-accepted",
+        status: "approved",
+        participant_name: "山田 花子",
+        opportunity_id: "opportunity-1",
+        opportunity_title: "地域清掃ボランティア",
+        applied_at: "2026-06-01T09:00:00.000Z",
+        status_changed_at: "2026-06-10T12:30:00.000Z",
+        match_score: 87.4,
+      },
+      {
+        id: "application-declined",
+        status: "rejected",
+        participant_name: "佐藤 太郎",
+        opportunity_id: "opportunity-2",
+        opportunity_title: "学習支援スタッフ",
+        applied_at: null,
+        status_changed_at: "2026-06-09T08:15:00.000Z",
+        match_score: null,
+      },
+    ]);
+    expect(mockFindOrganizationProfile).toHaveBeenCalledWith({
+      where: { userId: "organization-user-1" },
+      select: {
+        id: true,
+        reviewStatus: true,
+        user: { select: { role: true } },
+      },
+    });
+    expect(mockFindMatchingCandidates).toHaveBeenCalledWith({
+      where: {
+        status: { in: ["accepted", "declined"] },
+        opportunity: { organizationId: "org-profile-1" },
+      },
+      select: expect.objectContaining({
+        id: true,
+        status: true,
+        participant: expect.any(Object),
+        opportunity: expect.any(Object),
+      }),
+      orderBy: [
+        { statusChangedAt: "desc" },
+        { appliedAt: "desc" },
+        { id: "asc" },
+      ],
+    });
+  });
+
+  it("Prisma 例外時は予期しないエラーを返す", async () => {
+    mockFindMatchingCandidates.mockRejectedValue(new Error("DB error"));
+
+    const result = await fetchMatchingHistory();
+
+    expect(result.history).toEqual([]);
+    expect(result.error).toBe("予期しないエラーが発生しました");
+  });
+});

--- a/app/src/lib/dashboard/types.ts
+++ b/app/src/lib/dashboard/types.ts
@@ -70,6 +70,40 @@ export interface UpdateOpportunityResult {
 /** 応募ステータス */
 export type ApplicationStatus = "pending" | "approved" | "rejected" | "completed";
 
+/** マッチング履歴に表示する応募ステータス */
+export type MatchingHistoryStatus = Extract<
+  ApplicationStatus,
+  "approved" | "rejected"
+>;
+
+/** 団体向けマッチング履歴の1件 */
+export interface MatchingHistoryItem {
+  /** 応募ID */
+  id: string;
+  /** 履歴表示用ステータス */
+  status: MatchingHistoryStatus;
+  /** 応募者名 */
+  participant_name: string;
+  /** 案件ID */
+  opportunity_id: string;
+  /** 案件タイトル */
+  opportunity_title: string;
+  /** 応募日時 */
+  applied_at: string | null;
+  /** 承認・辞退の処理日時 */
+  status_changed_at: string;
+  /** マッチングスコア (0-100) */
+  match_score: number | null;
+}
+
+/** fetchMatchingHistory の戻り値 */
+export interface MatchingHistoryResult {
+  /** 自団体の承認・辞退済み応募履歴 */
+  history: MatchingHistoryItem[];
+  /** エラーメッセージ */
+  error?: string;
+}
+
 /** 応募者情報（applications + participants JOIN 結果） */
 export interface Applicant {
   /** 応募ID */


### PR DESCRIPTION
## 概要
- 団体ダッシュボードに `/dashboard/history` を追加
- 自団体の承認済み・辞退済み応募を一覧表示
- 団体ロール・承認済み団体の認可チェックとユニットテストを追加

## 変更内容
- `fetchMatchingHistory()` を `lib/dashboard/actions.ts` に追加
- マッチング履歴用の型を `lib/dashboard/types.ts` に追加
- `/dashboard/history` ページと `/dashboard` からの導線を追加
- `accepted` / `declined` を UI 表示用の `approved` / `rejected` に変換

## 確認
- `cd app && npx -y node@22 ./node_modules/vitest/vitest.mjs run src/lib/dashboard/matching-history.test.ts`
- `cd app && npx -y node@22 ./node_modules/vitest/vitest.mjs run src/lib/dashboard/*.test.ts`
- `cd app && npx -y node@22 ./node_modules/vitest/vitest.mjs run`
- `cd app && npx -y node@22 ./node_modules/eslint/bin/eslint.js`（既存 warning 1件のみ）

## 補足
- `next build` は TypeScript フェーズ通過後、既存の Supabase 環境変数未設定により `/admin/reviews` の prerender で停止しました。

Closes #126
