### PR TITLE
chore: centralize MCP config sync

### DIFF
--- a/.agent-shared/mcp/servers.json
+++ b/.agent-shared/mcp/servers.json
@@ -25,7 +25,9 @@
         "serena",
         "start-mcp-server",
         "--context",
-        "ide-assistant"
+        "ide-assistant",
+        "--open-web-dashboard",
+        "false"
       ]
     },
     "Vercel": {

--- a/.agent-shared/scripts/codex-worktree-setup.sh
+++ b/.agent-shared/scripts/codex-worktree-setup.sh
@@ -64,6 +64,24 @@ configure_supported_node() {
   hash -r
 }
 
+sync_codex_mcp_config() {
+  local sync_script="$repo_root/.agent-shared/scripts/sync-agent-mcp.mjs"
+  local codex_config="$repo_root/.codex/config.toml"
+
+  if [ ! -f "$sync_script" ]; then
+    log "MCP 同期スクリプトが見つからないため、Codex MCP 設定の同期をスキップします。"
+    return 0
+  fi
+
+  if [ ! -f "$repo_root/.agent-shared/mcp/servers.json" ]; then
+    log "MCP サーバー定義が見つからないため、Codex MCP 設定の同期をスキップします。"
+    return 0
+  fi
+
+  log "Codex MCP 設定を同期します。"
+  node "$repo_root/.agent-shared/scripts/sync-agent-mcp.mjs" --codex-config "$repo_root/.codex/config.toml"
+}
+
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 app_dir="$repo_root/app"
 
@@ -80,6 +98,8 @@ log "Repository: $repo_root"
 log "Node: $(node --version 2>/dev/null || printf 'not found')"
 log "npm: $(npm --version 2>/dev/null || printf 'not found')"
 log "Docker / Supabase / dev server は起動しません。"
+
+sync_codex_mcp_config
 
 if [ ! -f "$app_dir/.env.local" ]; then
   log "app/.env.local がありません。必要な場合は local checkout で用意し、.worktreeinclude で worktree にコピーしてください。"

--- a/.agent-shared/scripts/sync-agent-mcp.mjs
+++ b/.agent-shared/scripts/sync-agent-mcp.mjs
@@ -28,6 +28,9 @@ for (let i = 2; i < process.argv.length; i += 1) {
 const sourcePath = path.resolve(String(args.get("source") || defaultSource));
 const outDir = path.resolve(String(args.get("out-dir") || defaultOutDir));
 const stdoutOnly = args.has("stdout");
+const codexConfigPath = args.has("codex-config")
+  ? path.resolve(String(args.get("codex-config")))
+  : null;
 
 const raw = JSON.parse(await readFile(sourcePath, "utf8"));
 const servers = raw.servers && typeof raw.servers === "object" ? raw.servers : raw;
@@ -95,11 +98,13 @@ function pushInlineObject(lines, key, value) {
   lines.push(`${key} = { ${body} }`);
 }
 
-function toCodexToml(allServers) {
-  const lines = [
-    "# Generated from ~/.agent-shared/mcp/servers.json.",
-    "# Review this file before copying sections into ~/.codex/config.toml or .codex/config.toml.",
-  ];
+function toCodexToml(allServers, options = {}) {
+  const lines =
+    options.headerLines ||
+    [
+      "# Generated from ~/.agent-shared/mcp/servers.json.",
+      "# Review this file before copying sections into ~/.codex/config.toml or .codex/config.toml.",
+    ];
 
   for (const [name, server] of Object.entries(allServers)) {
     lines.push("", `[mcp_servers.${name}]`);
@@ -133,6 +138,65 @@ function toCodexToml(allServers) {
   return `${lines.join("\n")}\n`;
 }
 
+function isTomlTableHeader(line) {
+  return /^\s*\[[^\]]+\]\s*(?:#.*)?$/.test(line);
+}
+
+function isMcpTableHeader(line) {
+  return /^\s*\[mcp_servers(?:\]|\.)/.test(line);
+}
+
+function stripCodexMcpSections(toml) {
+  const lines = toml.replace(/\r\n/g, "\n").split("\n");
+  const keptLines = [];
+  let skippingMcpSection = false;
+
+  for (const line of lines) {
+    if (isMcpTableHeader(line)) {
+      skippingMcpSection = true;
+      continue;
+    }
+
+    if (skippingMcpSection) {
+      if (isTomlTableHeader(line)) {
+        skippingMcpSection = false;
+        keptLines.push(line);
+      }
+      continue;
+    }
+
+    keptLines.push(line);
+  }
+
+  while (keptLines.at(-1)?.trim() === "") {
+    keptLines.pop();
+  }
+
+  return keptLines.join("\n");
+}
+
+function mergeCodexConfig(existingToml, generatedMcpToml) {
+  const nonMcpToml = stripCodexMcpSections(existingToml).trimEnd();
+  const mcpToml = generatedMcpToml.trimEnd();
+
+  if (!nonMcpToml) {
+    return `${mcpToml}\n`;
+  }
+
+  return `${nonMcpToml}\n\n${mcpToml}\n`;
+}
+
+async function readOptionalFile(filePath) {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
 const claudeConfig = {
   mcpServers: Object.fromEntries(
     Object.entries(servers).map(([name, server]) => [name, toClaudeServer(server)]),
@@ -140,6 +204,13 @@ const claudeConfig = {
 };
 const claudeJson = `${JSON.stringify(claudeConfig, null, 2)}\n`;
 const codexToml = toCodexToml(servers);
+const codexConfigMcpToml = toCodexToml(servers, {
+  headerLines: [
+    "# MCP server sections generated from .agent-shared/mcp/servers.json.",
+    "# Edit .agent-shared/mcp/servers.json, then rerun:",
+    "# node .agent-shared/scripts/sync-agent-mcp.mjs --codex-config .codex/config.toml",
+  ],
+});
 
 if (stdoutOnly) {
   console.log("## claude.mcp.json");
@@ -152,5 +223,14 @@ if (stdoutOnly) {
   await writeFile(path.join(outDir, "codex.config.generated.toml"), codexToml);
   console.log(`Generated ${path.join(outDir, "claude.mcp.json")}`);
   console.log(`Generated ${path.join(outDir, "codex.config.generated.toml")}`);
-  console.log("既存の Claude Code/Codex MCP 設定は上書きしていません。");
+
+  if (codexConfigPath) {
+    const existingCodexConfig = await readOptionalFile(codexConfigPath);
+    const updatedCodexConfig = mergeCodexConfig(existingCodexConfig, codexConfigMcpToml);
+    await mkdir(path.dirname(codexConfigPath), { recursive: true });
+    await writeFile(codexConfigPath, updatedCodexConfig);
+    console.log(`Updated ${codexConfigPath}`);
+  } else {
+    console.log("既存の Claude Code/Codex MCP 設定は上書きしていません。");
+  }
 }

--- a/.agent-shared/scripts/sync-agent-mcp.mjs
+++ b/.agent-shared/scripts/sync-agent-mcp.mjs
@@ -146,12 +146,24 @@ function isMcpTableHeader(line) {
   return /^\s*\[mcp_servers(?:\]|\.)/.test(line);
 }
 
+function isGeneratedMcpComment(line) {
+  return (
+    line === "# MCP server sections generated from .agent-shared/mcp/servers.json." ||
+    line === "# Edit .agent-shared/mcp/servers.json, then rerun:" ||
+    line === "# node .agent-shared/scripts/sync-agent-mcp.mjs --codex-config .codex/config.toml"
+  );
+}
+
 function stripCodexMcpSections(toml) {
   const lines = toml.replace(/\r\n/g, "\n").split("\n");
   const keptLines = [];
   let skippingMcpSection = false;
 
   for (const line of lines) {
+    if (isGeneratedMcpComment(line)) {
+      continue;
+    }
+
     if (isMcpTableHeader(line)) {
       skippingMcpSection = true;
       continue;

--- a/.agent-shared/scripts/sync-agent-mcp.test.mjs
+++ b/.agent-shared/scripts/sync-agent-mcp.test.mjs
@@ -73,8 +73,18 @@ test("updates only MCP sections in a Codex config from the shared server source"
     "--codex-config",
     codexConfigPath,
   ]);
+  await execFileAsync("node", [
+    scriptPath,
+    "--source",
+    sourcePath,
+    "--out-dir",
+    outDir,
+    "--codex-config",
+    codexConfigPath,
+  ]);
 
   const updatedConfig = await readFile(codexConfigPath, "utf8");
+  const generatedHeaderCount = updatedConfig.match(/MCP server sections generated/g)?.length ?? 0;
 
   assert.match(updatedConfig, /personality = "friendly"/);
   assert.match(updatedConfig, /\[profiles\.local\]/);
@@ -83,4 +93,17 @@ test("updates only MCP sections in a Codex config from the shared server source"
   assert.match(updatedConfig, /\[mcp_servers\.serena\]/);
   assert.match(updatedConfig, /"--open-web-dashboard", "false"/);
   assert.match(updatedConfig, /\[mcp_servers\.vercel\]/);
+  assert.equal(generatedHeaderCount, 1);
+});
+
+test("Codex worktree setup syncs Codex MCP config from the shared server source", async () => {
+  const setupScript = await readFile(
+    fileURLToPath(new URL("./codex-worktree-setup.sh", import.meta.url)),
+    "utf8",
+  );
+
+  assert.match(
+    setupScript,
+    /node "\$repo_root\/\.agent-shared\/scripts\/sync-agent-mcp\.mjs" --codex-config "\$repo_root\/\.codex\/config\.toml"/,
+  );
 });

--- a/.agent-shared/scripts/sync-agent-mcp.test.mjs
+++ b/.agent-shared/scripts/sync-agent-mcp.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = fileURLToPath(new URL("./sync-agent-mcp.mjs", import.meta.url));
+
+test("updates only MCP sections in a Codex config from the shared server source", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "sync-agent-mcp-"));
+  const sourcePath = path.join(tempDir, "servers.json");
+  const outDir = path.join(tempDir, "generated");
+  const codexConfigPath = path.join(tempDir, "config.toml");
+
+  await mkdir(outDir, { recursive: true });
+  await writeFile(
+    sourcePath,
+    `${JSON.stringify(
+      {
+        version: 1,
+        servers: {
+          serena: {
+            type: "stdio",
+            command: "uvx",
+            args: [
+              "--from",
+              "git+https://github.com/oraios/serena",
+              "serena",
+              "start-mcp-server",
+              "--context",
+              "ide-assistant",
+              "--open-web-dashboard",
+              "false",
+            ],
+          },
+          vercel: {
+            type: "http",
+            url: "https://mcp.vercel.com",
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    codexConfigPath,
+    [
+      'personality = "friendly"',
+      "",
+      "[mcp_servers]",
+      "",
+      "[mcp_servers.old]",
+      'command = "old"',
+      'args = ["stale"]',
+      "",
+      "[profiles.local]",
+      'approval_policy = "never"',
+      "",
+    ].join("\n"),
+  );
+
+  await execFileAsync("node", [
+    scriptPath,
+    "--source",
+    sourcePath,
+    "--out-dir",
+    outDir,
+    "--codex-config",
+    codexConfigPath,
+  ]);
+
+  const updatedConfig = await readFile(codexConfigPath, "utf8");
+
+  assert.match(updatedConfig, /personality = "friendly"/);
+  assert.match(updatedConfig, /\[profiles\.local\]/);
+  assert.doesNotMatch(updatedConfig, /mcp_servers\.old/);
+  assert.doesNotMatch(updatedConfig, /stale/);
+  assert.match(updatedConfig, /\[mcp_servers\.serena\]/);
+  assert.match(updatedConfig, /"--open-web-dashboard", "false"/);
+  assert.match(updatedConfig, /\[mcp_servers\.vercel\]/);
+});

--- a/.agent-shared/skills/volunty-mcp-operations/SKILL.md
+++ b/.agent-shared/skills/volunty-mcp-operations/SKILL.md
@@ -10,6 +10,7 @@ argument-hint: '例: MCP設定を変更 / GitHub MCPトークンの扱い / .mcp
 - MCP サーバー定義の正は `.agent-shared/mcp/servers.json` とする。
 - `.codex/config.toml` の MCP セクションは直接編集せず、次のコマンドで同期する。
   `node .agent-shared/scripts/sync-agent-mcp.mjs --codex-config .codex/config.toml`
+- Codex worktree setup では `.agent-shared/scripts/codex-worktree-setup.sh` が同じ同期を自動実行する。
 - GitHub MCP の認証情報は `GITHUB_MCP_TOKEN` 環境変数からのみ注入する。
 - tracked file にトークンや認証情報を書かない。
 

--- a/.agent-shared/skills/volunty-mcp-operations/SKILL.md
+++ b/.agent-shared/skills/volunty-mcp-operations/SKILL.md
@@ -7,6 +7,9 @@ argument-hint: '例: MCP設定を変更 / GitHub MCPトークンの扱い / .mcp
 # MCP 運用
 
 - `.mcp.json` はローカル生成物であり、`.gitignore` 対象のためコミットしない。
+- MCP サーバー定義の正は `.agent-shared/mcp/servers.json` とする。
+- `.codex/config.toml` の MCP セクションは直接編集せず、次のコマンドで同期する。
+  `node .agent-shared/scripts/sync-agent-mcp.mjs --codex-config .codex/config.toml`
 - GitHub MCP の認証情報は `GITHUB_MCP_TOKEN` 環境変数からのみ注入する。
 - tracked file にトークンや認証情報を書かない。
 
@@ -14,4 +17,5 @@ argument-hint: '例: MCP設定を変更 / GitHub MCPトークンの扱い / .mcp
 
 - MCP 設定を変更する場合は、差分に秘密情報が含まれていないか確認する。
 - `.mcp.json` が意図せず追跡対象になっていないか確認する。
+- `.codex/config.toml` の MCP セクションが `.agent-shared/mcp/servers.json` から再生成されているか確認する。
 - 認証情報を README、docs、設定ファイル、テストデータへ書かない。

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,8 @@
 personality = "friendly"
 
-[mcp_servers]
+# MCP server sections generated from .agent-shared/mcp/servers.json.
+# Edit .agent-shared/mcp/servers.json, then rerun:
+# node .agent-shared/scripts/sync-agent-mcp.mjs --codex-config .codex/config.toml
 
 [mcp_servers.context7]
 command = "npx"
@@ -15,7 +17,7 @@ args = ["-y", "@playwright/mcp@latest"]
 
 [mcp_servers.serena]
 command = "uvx"
-args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "ide-assistant"]
+args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "ide-assistant", "--open-web-dashboard", "false"]
 
 [mcp_servers.Vercel]
 url = "https://mcp.vercel.com"


### PR DESCRIPTION
## Summary

- Treat `.agent-shared/mcp/servers.json` as the source of truth for MCP server definitions.
- Add `sync-agent-mcp.mjs --codex-config` to regenerate only the MCP sections in `.codex/config.toml` while preserving non-MCP settings.
- Disable Serena startup browser launch with `--open-web-dashboard false`.
- Run Codex MCP config sync automatically during Codex worktree setup.

## Verification

- `node --test .agent-shared/scripts/sync-agent-mcp.test.mjs`
- `bash -n .agent-shared/scripts/codex-worktree-setup.sh`
- `git diff --check HEAD~2..HEAD`
- Secret scan over MCP config and scripts

## Notes

- Draft PR because this changes local Codex/worktree setup behavior.
- `.agent-shared/mcp/generated/` remains ignored and is not included.
