### PR TITLE
feat: 応募詳細ページを追加

### DIFF
--- a/app/src/app/mypage/applications/[id]/page.tsx
+++ b/app/src/app/mypage/applications/[id]/page.tsx
@@ -1,0 +1,242 @@
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  MessageCircle,
+  MessageSquare,
+  MapPin,
+  Calendar,
+  Tag,
+  Monitor,
+  FileCheck2,
+} from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+import { Header } from "@/app/components/Header";
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import { fetchMyApplicationDetail } from "@/lib/mypage/actions";
+import type { ApplicationStatus } from "@/lib/mypage/types";
+
+export const dynamic = "force-dynamic";
+
+function statusDisplay(status: ApplicationStatus) {
+  switch (status) {
+    case "pending":
+      return {
+        label: "審査中",
+        icon: <Clock className="size-4" />,
+        color: "text-yellow-700 bg-yellow-50 border-yellow-200",
+      };
+    case "approved":
+      return {
+        label: "マッチング成立",
+        icon: <CheckCircle2 className="size-4" />,
+        color: "text-green-700 bg-green-50 border-green-200",
+      };
+    case "completed":
+      return {
+        label: "活動完了",
+        icon: <CheckCircle2 className="size-4" />,
+        color: "text-primary bg-primary/10 border-primary/20",
+      };
+    case "rejected":
+      return {
+        label: "辞退",
+        icon: <XCircle className="size-4" />,
+        color: "text-red-700 bg-red-50 border-red-200",
+      };
+  }
+}
+
+function formatDate(isoString: string | null): string | null {
+  if (!isoString) return null;
+  return new Date(isoString).toLocaleDateString("ja-JP");
+}
+
+function participationModeLabel(mode: string | null): string | null {
+  if (!mode) return null;
+  const labels: Record<string, string> = {
+    online: "オンライン",
+    offline: "対面",
+    hybrid: "ハイブリッド",
+  };
+  return labels[mode] ?? mode;
+}
+
+export default async function MyApplicationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { application, error } = await fetchMyApplicationDetail(id);
+
+  if (error === "ログインが必要です") {
+    redirect("/login");
+  }
+  if (!application) {
+    notFound();
+  }
+
+  const display = statusDisplay(application.status);
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <Link
+          href="/mypage"
+          className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          マイページに戻る
+        </Link>
+
+        <Card className="mb-6">
+          <CardContent>
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h1 className="text-xl font-bold text-text-dark">
+                  {application.opportunity.title}
+                </h1>
+                <p className="mt-1 text-sm text-text-body">
+                  {application.opportunity.organization_name}
+                </p>
+              </div>
+              <span
+                className={`inline-flex w-fit items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium ${display.color}`}
+              >
+                {display.icon}
+                {display.label}
+              </span>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-4 text-xs text-text-body">
+              <span>応募日: {formatDate(application.applied_at)}</span>
+              {application.completed_at && (
+                <span>完了日: {formatDate(application.completed_at)}</span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {application.message && (
+          <Card className="mb-6">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <MessageSquare className="size-5 text-primary" />
+                <h2 className="text-lg font-bold text-text-dark">
+                  応募メッセージ
+                </h2>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="whitespace-pre-wrap leading-7 text-text-body">
+                {application.message}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card className="mb-6">
+          <CardHeader>
+            <h2 className="text-lg font-bold text-text-dark">案件詳細</h2>
+          </CardHeader>
+          <CardContent>
+            <dl className="space-y-3 text-sm">
+              {application.opportunity.description && (
+                <div>
+                  <dt className="text-xs text-text-body">説明</dt>
+                  <dd className="mt-1 whitespace-pre-wrap leading-6 text-text-dark">
+                    {application.opportunity.description}
+                  </dd>
+                </div>
+              )}
+              {application.opportunity.location && (
+                <div className="flex items-center gap-2">
+                  <MapPin className="size-4 shrink-0 text-text-body" />
+                  <span className="text-text-body">場所</span>
+                  <span className="ml-auto text-text-dark">
+                    {application.opportunity.location}
+                  </span>
+                </div>
+              )}
+              {(application.opportunity.start_date ||
+                application.opportunity.end_date) && (
+                <div className="flex items-center gap-2">
+                  <Calendar className="size-4 shrink-0 text-text-body" />
+                  <span className="text-text-body">期間</span>
+                  <span className="ml-auto text-text-dark">
+                    {formatDate(application.opportunity.start_date) ?? "未定"}
+                    {" 〜 "}
+                    {formatDate(application.opportunity.end_date) ?? "未定"}
+                  </span>
+                </div>
+              )}
+              {application.opportunity.category && (
+                <div className="flex items-center gap-2">
+                  <Tag className="size-4 shrink-0 text-text-body" />
+                  <span className="text-text-body">カテゴリ</span>
+                  <span className="ml-auto text-text-dark">
+                    {application.opportunity.category}
+                  </span>
+                </div>
+              )}
+              {application.opportunity.participation_mode && (
+                <div className="flex items-center gap-2">
+                  <Monitor className="size-4 shrink-0 text-text-body" />
+                  <span className="text-text-body">参加形態</span>
+                  <span className="ml-auto text-text-dark">
+                    {participationModeLabel(
+                      application.opportunity.participation_mode
+                    )}
+                  </span>
+                </div>
+              )}
+              {!application.opportunity.description &&
+                !application.opportunity.location &&
+                !application.opportunity.start_date &&
+                !application.opportunity.end_date &&
+                !application.opportunity.category &&
+                !application.opportunity.participation_mode && (
+                  <p className="text-text-body">詳細情報はありません。</p>
+                )}
+            </dl>
+          </CardContent>
+        </Card>
+
+        {application.opportunity.organization_line_id && (
+          <Card className="mb-6">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <MessageCircle className="size-5 text-primary" />
+                <h2 className="text-lg font-bold text-text-dark">
+                  団体連絡先
+                </h2>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="rounded-lg bg-green-50 p-3">
+                <p className="text-xs text-green-700">LINE ID</p>
+                <p className="mt-1 font-medium text-green-800">
+                  {application.opportunity.organization_line_id}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {application.can_request_certificate && (
+          <Link
+            href={`/mypage/certificates/request/${application.id}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-primary/30 px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary/5"
+          >
+            <FileCheck2 className="size-4" />
+            参加証明書を申請する
+          </Link>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/src/app/mypage/page.tsx
+++ b/app/src/app/mypage/page.tsx
@@ -226,7 +226,7 @@ export default async function MyPage() {
                   return (
                     <div
                       key={app.id}
-                      className="rounded-lg border border-card-border p-4"
+                      className="rounded-lg border border-card-border p-4 transition-shadow hover:shadow-md"
                     >
                       <div className="flex flex-col gap-3">
                         <div className="flex items-start justify-between gap-2">
@@ -284,6 +284,12 @@ export default async function MyPage() {
                             証明書を申請
                           </Link>
                         )}
+                        <Link
+                          href={`/mypage/applications/${app.id}`}
+                          className="inline-flex w-fit items-center gap-2 text-xs font-medium text-primary hover:underline"
+                        >
+                          詳細を見る
+                        </Link>
                       </div>
                     </div>
                   );

--- a/app/src/lib/auth/ensure-user-record.test.ts
+++ b/app/src/lib/auth/ensure-user-record.test.ts
@@ -13,8 +13,13 @@ vi.mock("@/lib/prisma", () => ({
 
 const { ensureUserRecord } = await import("./ensure-user-record");
 
+type SupabaseUserFixture = Omit<Partial<SupabaseUser>, "email"> &
+  Pick<SupabaseUser, "id"> & {
+    email?: string | null;
+  };
+
 function createSupabaseUser(
-  user: Partial<SupabaseUser> & Pick<SupabaseUser, "id">
+  user: SupabaseUserFixture
 ): SupabaseUser {
   return {
     app_metadata: {},

--- a/app/src/lib/mypage/actions.test.ts
+++ b/app/src/lib/mypage/actions.test.ts
@@ -5,6 +5,7 @@ const mockGetUser = vi.fn();
 const mockFetchParticipantProfileByUserIdWithDebug = vi.fn();
 const mockDeleteManyUser = vi.fn();
 const mockDeleteAuthUser = vi.fn();
+const mockFindFirstMatchingCandidate = vi.fn();
 const mockRedirect = vi.fn();
 
 type MatchingRow = {
@@ -80,6 +81,9 @@ vi.mock("@/lib/prisma", () => ({
     user: {
       deleteMany: (...args: unknown[]) => mockDeleteManyUser(...args),
     },
+    matchingCandidate: {
+      findFirst: (...args: unknown[]) => mockFindFirstMatchingCandidate(...args),
+    },
   },
 }));
 
@@ -101,6 +105,7 @@ describe("fetchMyPageData", () => {
     mockMatchingRows = [];
     mockOpportunityRows = [];
     mockMatchingError = null;
+    mockFindFirstMatchingCandidate.mockResolvedValue(null);
     mockDeleteManyUser.mockResolvedValue({ count: 1 });
     mockDeleteAuthUser.mockResolvedValue({ data: { user: null }, error: null });
   });
@@ -311,6 +316,158 @@ describe("fetchMyPageData", () => {
 
     expect(result.profile).toBeNull();
     expect(result.applications).toEqual([]);
+  });
+});
+
+describe("fetchMyApplicationDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirstMatchingCandidate.mockResolvedValue(null);
+  });
+
+  it("未認証の場合、error を返す", async () => {
+    mockGetUser.mockReturnValue({
+      data: { user: null },
+      error: { message: "Not authenticated" },
+    });
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-1");
+
+    expect(result.application).toBeNull();
+    expect(result.error).toBe("ログインが必要です");
+  });
+
+  it("応募が見つからない場合、application が null でエラーなし", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    mockFindFirstMatchingCandidate.mockResolvedValue(null);
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("unknown-id");
+
+    expect(mockFindFirstMatchingCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "unknown-id",
+          participantId: "user-1",
+          status: { in: ["applied", "accepted", "completed", "declined"] },
+        }),
+      })
+    );
+    expect(result.application).toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it("pending ステータスの場合、LINE ID は null を返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    mockFindFirstMatchingCandidate.mockResolvedValue({
+      id: "app-1",
+      status: "applied",
+      message: "志望動機です",
+      appliedAt: new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      statusChangedAt: new Date("2026-01-01T00:00:00.000Z"),
+      opportunity: {
+        id: "opp-1",
+        title: "環境保全活動",
+        description: "説明テキスト",
+        location: "東京都",
+        startDate: new Date("2026-03-01"),
+        endDate: new Date("2026-03-31"),
+        category: "環境保全",
+        participationMode: "offline",
+        organization: {
+          organizationName: "NPO法人テスト",
+          contactLineId: "@test_line",
+        },
+      },
+    });
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-1");
+
+    expect(result.application).not.toBeNull();
+    expect(result.application?.status).toBe("pending");
+    expect(result.application?.message).toBe("志望動機です");
+    expect(result.application?.opportunity.organization_line_id).toBeNull();
+    expect(result.application?.can_request_certificate).toBe(false);
+  });
+
+  it("approved ステータスの場合、LINE ID を返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    mockFindFirstMatchingCandidate.mockResolvedValue({
+      id: "app-2",
+      status: "accepted",
+      message: null,
+      appliedAt: new Date("2026-02-01T00:00:00.000Z"),
+      createdAt: new Date("2026-02-01T00:00:00.000Z"),
+      statusChangedAt: new Date("2026-02-05T00:00:00.000Z"),
+      opportunity: {
+        id: "opp-2",
+        title: "子ども支援",
+        description: null,
+        location: null,
+        startDate: null,
+        endDate: null,
+        category: null,
+        participationMode: null,
+        organization: {
+          organizationName: "支援団体A",
+          contactLineId: "@line_a",
+        },
+      },
+    });
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-2");
+
+    expect(result.application?.status).toBe("approved");
+    expect(result.application?.opportunity.organization_line_id).toBe("@line_a");
+  });
+
+  it("completed ステータスの場合、証明書申請可能フラグと完了日を返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    const completedAt = new Date("2026-03-10T12:00:00.000Z");
+    mockFindFirstMatchingCandidate.mockResolvedValue({
+      id: "app-3",
+      status: "completed",
+      message: null,
+      appliedAt: new Date("2026-01-15T00:00:00.000Z"),
+      createdAt: new Date("2026-01-15T00:00:00.000Z"),
+      statusChangedAt: completedAt,
+      opportunity: {
+        id: "opp-3",
+        title: "清掃活動",
+        description: null,
+        location: null,
+        startDate: null,
+        endDate: null,
+        category: null,
+        participationMode: null,
+        organization: {
+          organizationName: "地域団体",
+          contactLineId: "@local",
+        },
+      },
+    });
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-3");
+
+    expect(result.application?.status).toBe("completed");
+    expect(result.application?.completed_at).toBe("2026-03-10T12:00:00.000Z");
+    expect(result.application?.can_request_certificate).toBe(true);
+  });
+
+  it("DB エラー時、エラーメッセージを返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    mockFindFirstMatchingCandidate.mockRejectedValue(new Error("DB error"));
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-1");
+
+    expect(result.application).toBeNull();
+    expect(result.error).toBe("予期しないエラーが発生しました");
   });
 });
 

--- a/app/src/lib/mypage/actions.ts
+++ b/app/src/lib/mypage/actions.ts
@@ -11,6 +11,7 @@ import type {
   ParticipantProfile,
   DataFetchAlert,
   DeleteAccountState,
+  ApplicationDetailResult,
 } from "./types";
 
 const MATCHING_CANDIDATE_STATUSES = [
@@ -279,4 +280,119 @@ export async function deleteMyAccount(
   }
 
   redirect("/login?accountDeleted=1");
+}
+
+/**
+ * 参加者の応募詳細取得
+ *
+ * - ログイン中ユーザーの応募のみ返す（participantId チェックで認可）
+ * - status = approved / completed の場合のみ LINE 連絡先を公開
+ */
+export async function fetchMyApplicationDetail(
+  applicationId: string
+): Promise<ApplicationDetailResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { application: null, error: "ログインが必要です" };
+  }
+
+  try {
+    const candidate = await prisma.matchingCandidate.findFirst({
+      where: {
+        id: applicationId,
+        participantId: user.id,
+        status: { in: [...MATCHING_CANDIDATE_STATUSES] },
+      },
+      select: {
+        id: true,
+        status: true,
+        message: true,
+        appliedAt: true,
+        createdAt: true,
+        statusChangedAt: true,
+        opportunity: {
+          select: {
+            id: true,
+            title: true,
+            description: true,
+            location: true,
+            startDate: true,
+            endDate: true,
+            category: true,
+            participationMode: true,
+            organization: {
+              select: {
+                organizationName: true,
+                contactLineId: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!candidate) {
+      return { application: null, error: null };
+    }
+
+    const rawStatus = candidate.status as string;
+    if (!isMatchingCandidateStatus(rawStatus)) {
+      return { application: null, error: null };
+    }
+
+    const status = MATCHING_STATUS_TO_APPLICATION_STATUS[rawStatus];
+    const showContact = status === "approved" || status === "completed";
+    const completedAt =
+      rawStatus === "completed"
+        ? candidate.statusChangedAt instanceof Date
+          ? candidate.statusChangedAt.toISOString()
+          : String(candidate.statusChangedAt)
+        : null;
+    const appliedAt =
+      candidate.appliedAt instanceof Date
+        ? candidate.appliedAt.toISOString()
+        : candidate.createdAt instanceof Date
+          ? candidate.createdAt.toISOString()
+          : String(candidate.createdAt);
+
+    return {
+      application: {
+        id: candidate.id,
+        status,
+        message: candidate.message ?? null,
+        applied_at: appliedAt,
+        completed_at: completedAt,
+        can_request_certificate: status === "completed",
+        opportunity: {
+          id: candidate.opportunity.id,
+          title: candidate.opportunity.title,
+          description: candidate.opportunity.description ?? null,
+          location: candidate.opportunity.location ?? null,
+          start_date:
+            candidate.opportunity.startDate instanceof Date
+              ? candidate.opportunity.startDate.toISOString()
+              : candidate.opportunity.startDate ?? null,
+          end_date:
+            candidate.opportunity.endDate instanceof Date
+              ? candidate.opportunity.endDate.toISOString()
+              : candidate.opportunity.endDate ?? null,
+          category: candidate.opportunity.category ?? null,
+          participation_mode: candidate.opportunity.participationMode ?? null,
+          organization_name: candidate.opportunity.organization.organizationName,
+          organization_line_id: showContact
+            ? (candidate.opportunity.organization.contactLineId ?? null)
+            : null,
+        },
+      },
+      error: null,
+    };
+  } catch (err) {
+    console.error("[fetchMyApplicationDetail] 予期しないエラー:", err);
+    return { application: null, error: "予期しないエラーが発生しました" };
+  }
 }

--- a/app/src/lib/mypage/types.ts
+++ b/app/src/lib/mypage/types.ts
@@ -58,3 +58,35 @@ export interface MyPageData {
 export interface DeleteAccountState {
   error: string | null;
 }
+
+/** 応募詳細の案件情報 */
+export interface ApplicationDetailOpportunity {
+  id: string;
+  title: string;
+  description: string | null;
+  location: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  category: string | null;
+  participation_mode: string | null;
+  organization_name: string;
+  /** マッチング成立（approved / completed）時のみ含まれる */
+  organization_line_id: string | null;
+}
+
+/** 応募詳細情報（fetchMyApplicationDetail の戻り値本体） */
+export interface ApplicationDetail {
+  id: string;
+  status: ApplicationStatus;
+  message: string | null;
+  applied_at: string;
+  completed_at: string | null;
+  can_request_certificate: boolean;
+  opportunity: ApplicationDetailOpportunity;
+}
+
+/** fetchMyApplicationDetail の戻り値 */
+export interface ApplicationDetailResult {
+  application: ApplicationDetail | null;
+  error: string | null;
+}


### PR DESCRIPTION
## Summary

- /mypage/applications/[id] の応募詳細ページを追加
- 本人の応募だけ取得する fetchMyApplicationDetail を追加し、approved/completed のみ LINE ID を公開
- マイページ応募一覧から詳細ページへの導線を追加
- 応募詳細の Server Action テストと型定義を追加
- 型チェックを通すため ensure-user-record のテスト fixture 型を補正

Closes #128

## Verification

- cd app && npx tsc --noEmit: 成功
- cd app && npm run lint: 成功（既存 warning 1 件: src/lib/dashboard/update-opportunity.test.ts の _args）
- cd app && npx vitest run: 成功（42 files / 280 tests）
- git diff --check: 成功

## Notes

- マイページ一覧の導線は、既存の証明書申請リンクとネストしないようカード全体リンクではなく「詳細を見る」リンクにしています。