### PR TITLE
feat: 管理ダッシュボードを追加

### DIFF
--- a/app/src/app/admin/page.test.tsx
+++ b/app/src/app/admin/page.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  getUser: vi.fn(),
+  userFindUnique: vi.fn(),
+  fetchDashboardStats: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    mocks.redirect(url);
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mocks.getUser(),
+    },
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => mocks.userFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock("@/app/components/Header", () => ({
+  Header: () => <header>ヘッダー</header>,
+}));
+
+vi.mock("@/lib/admin/actions", () => ({
+  fetchDashboardStats: (...args: unknown[]) =>
+    mocks.fetchDashboardStats(...args),
+}));
+
+import AdminDashboardPage from "./page";
+
+describe("AdminDashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUser.mockReturnValue({ data: { user: { id: "admin-1" } } });
+    mocks.userFindUnique.mockResolvedValue({ role: "admin" });
+    mocks.fetchDashboardStats.mockResolvedValue({
+      userCount: 1234,
+      matchingCount: 56,
+      pendingReviewCount: 7,
+    });
+  });
+
+  it("管理者にはサマリカードと団体審査導線を表示する", async () => {
+    const page = await AdminDashboardPage();
+    render(page);
+
+    expect(
+      screen.getByRole("heading", { name: "管理ダッシュボード" })
+    ).toBeDefined();
+    expect(screen.getByText("ユーザー数")).toBeDefined();
+    expect(screen.getByText("1,234")).toBeDefined();
+    expect(screen.getByText("マッチング数")).toBeDefined();
+    expect(screen.getByText("56")).toBeDefined();
+    expect(screen.getByText("審査待ち件数")).toBeDefined();
+    expect(screen.getByText("7")).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: /団体審査一覧/ }).getAttribute("href")
+    ).toBe("/admin/organizations");
+    expect(mocks.fetchDashboardStats).toHaveBeenCalledOnce();
+  });
+
+  it("未ログインユーザーはログイン画面へリダイレクトする", async () => {
+    mocks.getUser.mockReturnValue({ data: { user: null } });
+
+    await expect(AdminDashboardPage()).rejects.toThrow("NEXT_REDIRECT:/login");
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/login");
+    expect(mocks.userFindUnique).not.toHaveBeenCalled();
+    expect(mocks.fetchDashboardStats).not.toHaveBeenCalled();
+  });
+
+  it("admin 以外のユーザーは forbidden へリダイレクトする", async () => {
+    mocks.userFindUnique.mockResolvedValue({ role: "participant" });
+
+    await expect(AdminDashboardPage()).rejects.toThrow(
+      "NEXT_REDIRECT:/forbidden"
+    );
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/forbidden");
+    expect(mocks.fetchDashboardStats).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import {
+  ClipboardCheck,
+  Handshake,
+  LayoutDashboard,
+  Users,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Header } from "@/app/components/Header";
+import { Card, CardContent } from "@/app/components/ui/Card";
+import { fetchDashboardStats } from "@/lib/admin/actions";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+
+interface SummaryCard {
+  label: string;
+  value: number;
+  icon: LucideIcon;
+  href?: string;
+}
+
+export default async function AdminDashboardPage() {
+  // 管理者チェック
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { role: true },
+  });
+
+  if (!dbUser || dbUser.role !== "admin") {
+    redirect("/forbidden");
+  }
+
+  const stats = await fetchDashboardStats();
+  const cards: SummaryCard[] = [
+    {
+      label: "ユーザー数",
+      value: stats.userCount,
+      icon: Users,
+    },
+    {
+      label: "マッチング数",
+      value: stats.matchingCount,
+      icon: Handshake,
+    },
+    {
+      label: "審査待ち件数",
+      value: stats.pendingReviewCount,
+      icon: ClipboardCheck,
+      href: "/admin/organizations",
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <div className="mb-8 flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+            <LayoutDashboard className="size-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">
+              管理ダッシュボード
+            </h1>
+            <p className="text-sm text-text-body">サービス全体のサマリ</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {cards.map((card) => (
+            <DashboardSummaryCard key={card.label} card={card} />
+          ))}
+        </div>
+
+        <nav className="mt-8 flex flex-col gap-2">
+          <Link
+            href="/admin/organizations"
+            className="flex items-center gap-2 rounded-lg border border-card-border bg-white px-4 py-3 text-sm font-medium text-text-dark transition-colors hover:bg-background"
+          >
+            <ClipboardCheck className="size-4 text-primary" />
+            団体審査一覧
+          </Link>
+        </nav>
+      </main>
+    </div>
+  );
+}
+
+function DashboardSummaryCard({ card }: { card: SummaryCard }) {
+  const Icon = card.icon;
+  const content = (
+    <Card
+      className={`h-full ${card.href ? "transition-opacity hover:opacity-80" : ""}`}
+    >
+      <CardContent className="gap-3">
+        <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+          <Icon className="size-5 text-primary" />
+        </div>
+        <p className="text-sm text-text-body">{card.label}</p>
+        <p className="text-3xl font-bold text-text-dark">
+          {card.value.toLocaleString("ja-JP")}
+        </p>
+      </CardContent>
+    </Card>
+  );
+
+  if (card.href) {
+    return (
+      <Link href={card.href} className="block h-full">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}

--- a/app/src/lib/admin/actions.test.ts
+++ b/app/src/lib/admin/actions.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetUser = vi.fn();
 const mockFindUser = vi.fn();
+const mockCountUsers = vi.fn();
+const mockCountMatchingCandidates = vi.fn();
+const mockCountOrganizations = vi.fn();
 const mockFindOrganizations = vi.fn();
 const mockUpdateOrganization = vi.fn();
 const mockRevalidatePath = vi.fn();
@@ -22,15 +25,25 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     user: {
       findUnique: (...args: unknown[]) => mockFindUser(...args),
+      count: (...args: unknown[]) => mockCountUsers(...args),
+    },
+    matchingCandidate: {
+      count: (...args: unknown[]) => mockCountMatchingCandidates(...args),
     },
     organizationProfile: {
+      count: (...args: unknown[]) => mockCountOrganizations(...args),
       findMany: (...args: unknown[]) => mockFindOrganizations(...args),
       update: (...args: unknown[]) => mockUpdateOrganization(...args),
     },
   },
 }));
 
-const { fetchOrganizations, approveOrganization, rejectOrganization } = await import("./actions");
+const {
+  fetchDashboardStats,
+  fetchOrganizations,
+  approveOrganization,
+  rejectOrganization,
+} = await import("./actions");
 
 describe("admin/actions", () => {
   beforeEach(() => {
@@ -73,6 +86,29 @@ describe("admin/actions", () => {
         createdAt: "2026-04-17T10:00:00.000Z",
       }),
     ]);
+  });
+
+  it("管理ダッシュボード用のサマリ件数を取得する", async () => {
+    mockCountUsers.mockResolvedValue(12);
+    mockCountMatchingCandidates.mockResolvedValue(34);
+    mockCountOrganizations.mockResolvedValue(5);
+
+    const result = await fetchDashboardStats();
+
+    expect(result).toEqual({
+      userCount: 12,
+      matchingCount: 34,
+      pendingReviewCount: 5,
+    });
+    expect(mockCountUsers).toHaveBeenCalledWith({
+      where: { role: { not: "admin" } },
+    });
+    expect(mockCountMatchingCandidates).toHaveBeenCalledWith({
+      where: { status: { in: ["applied", "accepted", "completed"] } },
+    });
+    expect(mockCountOrganizations).toHaveBeenCalledWith({
+      where: { reviewStatus: "pending" },
+    });
   });
 
   it("承認時に承認状態と監査情報を更新する", async () => {

--- a/app/src/lib/admin/actions.ts
+++ b/app/src/lib/admin/actions.ts
@@ -48,6 +48,31 @@ export interface PendingOrganization {
   createdAt: string;
 }
 
+export interface DashboardStats {
+  userCount: number;
+  matchingCount: number;
+  pendingReviewCount: number;
+}
+
+/** 管理ダッシュボード用のサマリ件数を取得する */
+export async function fetchDashboardStats(): Promise<DashboardStats> {
+  await requireAdmin();
+
+  const [userCount, matchingCount, pendingReviewCount] = await Promise.all([
+    prisma.user.count({
+      where: { role: { not: "admin" } },
+    }),
+    prisma.matchingCandidate.count({
+      where: { status: { in: ["applied", "accepted", "completed"] } },
+    }),
+    prisma.organizationProfile.count({
+      where: { reviewStatus: "pending" },
+    }),
+  ]);
+
+  return { userCount, matchingCount, pendingReviewCount };
+}
+
 export async function fetchOrganizations(): Promise<PendingOrganization[]> {
   await requireAdmin();
 

--- a/app/src/lib/auth/ensure-user-record.test.ts
+++ b/app/src/lib/auth/ensure-user-record.test.ts
@@ -14,7 +14,8 @@ vi.mock("@/lib/prisma", () => ({
 const { ensureUserRecord } = await import("./ensure-user-record");
 
 function createSupabaseUser(
-  user: Partial<SupabaseUser> & Pick<SupabaseUser, "id">
+  user: Omit<Partial<SupabaseUser>, "email"> &
+    Pick<SupabaseUser, "id"> & { email?: string | null }
 ): SupabaseUser {
   return {
     app_metadata: {},


### PR DESCRIPTION
## Summary

- `/admin` に管理ダッシュボードページを追加
- ユーザー数、マッチング数、審査待ち件数を取得する `fetchDashboardStats()` を追加
- admin ロール認可、未ログイン、非 admin リダイレクトのテストを追加

Closes #129

## Verification

- `cd app && npx tsc --noEmit`: 成功
- `cd app && npx vitest run src/lib/admin/actions.test.ts src/app/admin/page.test.tsx src/lib/auth/ensure-user-record.test.ts`: 成功（12 tests）
- `cd app && npm run test`: 成功（43 files / 278 tests）
- `cd app && npm run lint`: 成功（既存 warning: `src/lib/dashboard/update-opportunity.test.ts:15` の未使用 `_args`）
- `curl -I http://localhost:3000/admin`: 未ログイン時に `/login?next=%2Fadmin` へ 307 リダイレクト

## Notes

- `npx tsc --noEmit` の既存失敗を解消するため、`ensure-user-record.test.ts` の Supabase user テストヘルパーで `email: null` を許容する型修正を含めています。