### PR TITLE
chore: GitHub MCPサーバー設定を追加

### DIFF
--- a/.agent-shared/mcp/servers.json
+++ b/.agent-shared/mcp/servers.json
@@ -33,6 +33,14 @@
     "Vercel": {
       "type": "http",
       "url": "https://mcp.vercel.com"
+    },
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_TOKEN}"
+      }
     }
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,6 +20,7 @@
     "figma",
     "playwright",
     "serena",
-    "Vercel"
+    "Vercel",
+    "github"
   ]
 }


### PR DESCRIPTION
## Summary

- `.agent-shared/mcp/servers.json` に GitHub MCP サーバー (`@modelcontextprotocol/server-github`) を追加
- `.claude/settings.local.json` の許可リストに `"github"` を追加
- トークンは `${GITHUB_MCP_TOKEN}` 環境変数参照のため、シークレット混入なし

## Verification

- `git diff --cached` でシークレット非混入を確認: 成功

## Notes

- 既存の Vercel MCP 設定に倣った構成