### PR TITLE
feat: 団体審査詳細画面を追加

### DIFF
--- a/app/src/app/admin/organizations/OrganizationReviewList.tsx
+++ b/app/src/app/admin/organizations/OrganizationReviewList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useTransition } from "react";
 import {
   CheckCircle2,
@@ -13,6 +14,7 @@ import {
   FileText,
   Tag,
   BarChart3,
+  ExternalLink,
 } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
 import { Button } from "@/app/components/ui/Button";
@@ -256,15 +258,24 @@ export function OrganizationReviewList({ organizations: initial }: Props) {
                   </div>
 
                   {/* 詳細トグル */}
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setExpandedId(isExpanded ? null : org.id)
-                    }
-                    className="cursor-pointer text-sm font-medium text-primary hover:underline"
-                  >
-                    {isExpanded ? "詳細を閉じる" : "詳細を表示"}
-                  </button>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setExpandedId(isExpanded ? null : org.id)
+                      }
+                      className="cursor-pointer text-left text-sm font-medium text-primary hover:underline"
+                    >
+                      {isExpanded ? "詳細を閉じる" : "詳細を表示"}
+                    </button>
+                    <Link
+                      href={`/admin/reviews/${org.id}`}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                    >
+                      <ExternalLink className="size-3.5" />
+                      詳細画面を開く
+                    </Link>
+                  </div>
 
                   {/* 展開時の詳細 */}
                   {isExpanded && (

--- a/app/src/app/admin/reviews/[id]/OrganizationReviewDetail.test.tsx
+++ b/app/src/app/admin/reviews/[id]/OrganizationReviewDetail.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingOrganization } from "@/lib/admin/actions";
+import { OrganizationReviewDetail } from "./OrganizationReviewDetail";
+
+const mocks = vi.hoisted(() => ({
+  approveOrganization: vi.fn(),
+  rejectOrganization: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}));
+
+vi.mock("@/lib/admin/actions", () => ({
+  approveOrganization: (...args: unknown[]) =>
+    mocks.approveOrganization(...args),
+  rejectOrganization: (...args: unknown[]) => mocks.rejectOrganization(...args),
+}));
+
+function organization(
+  override: Partial<PendingOrganization> = {}
+): PendingOrganization {
+  return {
+    id: "org-1",
+    userId: "user-1",
+    organizationName: "テスト団体",
+    representativeName: "担当者",
+    contactEmail: "org@example.com",
+    activityAreas: ["東京都"],
+    description: "団体説明",
+    activityCategories: ["子ども支援"],
+    websiteUrl: "https://example.com",
+    profileCompleteness: 80,
+    reviewStatus: "pending",
+    reviewComment: null,
+    reviewedAt: null,
+    reviewedBy: null,
+    verified: false,
+    createdAt: "2026-04-17T10:00:00.000Z",
+    ...override,
+  };
+}
+
+describe("OrganizationReviewDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("団体詳細と却下理由入力付きの操作を表示する", () => {
+    render(<OrganizationReviewDetail organization={organization()} />);
+
+    expect(
+      screen.getByRole("heading", { name: "テスト団体" })
+    ).toBeDefined();
+    expect(screen.getByText("代表者:")).toBeDefined();
+    expect(screen.getByText("東京都")).toBeDefined();
+    expect(screen.getByText("子ども支援")).toBeDefined();
+    expect(screen.getByLabelText("却下理由")).toBeDefined();
+    expect(
+      (screen.getByRole("button", { name: /否認する/ }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+  });
+
+  it("却下理由を入力すると否認アクションを実行して一覧へ戻る", async () => {
+    mocks.rejectOrganization.mockResolvedValue({ success: true });
+
+    render(<OrganizationReviewDetail organization={organization()} />);
+
+    fireEvent.change(screen.getByLabelText("却下理由"), {
+      target: { value: "情報を補足してください" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /否認する/ }));
+
+    await waitFor(() => {
+      expect(mocks.rejectOrganization).toHaveBeenCalledWith(
+        "org-1",
+        "情報を補足してください"
+      );
+    });
+    expect(mocks.push).toHaveBeenCalledWith("/admin/reviews");
+  });
+
+  it("審査済みの団体では操作フォームを表示しない", () => {
+    render(
+      <OrganizationReviewDetail
+        organization={organization({
+          reviewStatus: "approved",
+          verified: true,
+          reviewedAt: "2026-04-18T10:00:00.000Z",
+          reviewedBy: "admin-1",
+        })}
+      />
+    );
+
+    expect(screen.queryByLabelText("却下理由")).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: /承認済み/ }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+  });
+});

--- a/app/src/app/admin/reviews/[id]/OrganizationReviewDetail.tsx
+++ b/app/src/app/admin/reviews/[id]/OrganizationReviewDetail.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  AlertCircle,
+  BarChart3,
+  Building2,
+  CheckCircle2,
+  FileText,
+  Globe,
+  Mail,
+  MapPin,
+  Tag,
+  User,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/app/components/ui/Button";
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import type { PendingOrganization } from "@/lib/admin/actions";
+import {
+  approveOrganization,
+  rejectOrganization,
+} from "@/lib/admin/actions";
+
+interface Props {
+  organization: PendingOrganization;
+}
+
+function getStatusView(status: PendingOrganization["reviewStatus"]) {
+  switch (status) {
+    case "approved":
+      return {
+        icon: CheckCircle2,
+        label: "承認済み",
+        chipClass: "border-green-200 bg-green-50 text-green-700",
+        iconClass: "text-green-600",
+        avatarClass: "bg-green-50",
+      };
+    case "rejected":
+      return {
+        icon: AlertCircle,
+        label: "否認済み",
+        chipClass: "border-red-200 bg-red-50 text-red-700",
+        iconClass: "text-red-600",
+        avatarClass: "bg-red-50",
+      };
+    default:
+      return {
+        icon: XCircle,
+        label: "審査待ち",
+        chipClass: "border-yellow-200 bg-yellow-50 text-yellow-700",
+        iconClass: "text-yellow-600",
+        avatarClass: "bg-yellow-50",
+      };
+  }
+}
+
+export function OrganizationReviewDetail({ organization }: Props) {
+  const router = useRouter();
+  const [reviewComment, setReviewComment] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const statusView = getStatusView(organization.reviewStatus);
+  const StatusIcon = statusView.icon;
+  const isReviewable = organization.reviewStatus === "pending";
+  const normalizedComment = reviewComment.trim();
+
+  const handleApprove = () => {
+    startTransition(async () => {
+      setFeedback(null);
+      const result = await approveOrganization(organization.id);
+      if (result.success) {
+        router.push("/admin/reviews");
+        return;
+      }
+
+      setFeedback(result.error ?? "承認に失敗しました");
+    });
+  };
+
+  const handleReject = () => {
+    if (!normalizedComment) {
+      setFeedback("否認理由を入力してください");
+      return;
+    }
+
+    startTransition(async () => {
+      setFeedback(null);
+      const result = await rejectOrganization(
+        organization.id,
+        normalizedComment
+      );
+      if (result.success) {
+        router.push("/admin/reviews");
+        return;
+      }
+
+      setFeedback(result.error ?? "否認に失敗しました");
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div
+                className={`flex size-12 items-center justify-center rounded-full ${statusView.avatarClass}`}
+              >
+                <Building2 className={`size-6 ${statusView.iconClass}`} />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-text-dark">
+                  {organization.organizationName}
+                </h2>
+                <p className="text-xs text-text-body">
+                  申請日:{" "}
+                  {new Date(organization.createdAt).toLocaleDateString(
+                    "ja-JP"
+                  )}
+                </p>
+              </div>
+            </div>
+            <span
+              className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium ${statusView.chipClass}`}
+            >
+              <StatusIcon className="size-3.5" />
+              {statusView.label}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {organization.representativeName && (
+              <div className="flex items-center gap-2 text-sm">
+                <User className="size-4 shrink-0 text-text-body/60" />
+                <span className="text-text-body">代表者:</span>
+                <span className="font-medium text-text-dark">
+                  {organization.representativeName}
+                </span>
+              </div>
+            )}
+            {organization.contactEmail && (
+              <div className="flex items-center gap-2 text-sm">
+                <Mail className="size-4 shrink-0 text-text-body/60" />
+                <span className="text-text-body">連絡先:</span>
+                <span className="font-medium text-text-dark">
+                  {organization.contactEmail}
+                </span>
+              </div>
+            )}
+            <div className="flex items-center gap-2 text-sm">
+              <BarChart3 className="size-4 shrink-0 text-text-body/60" />
+              <span className="text-text-body">充実度:</span>
+              <div className="flex items-center gap-2">
+                <div className="h-2 w-24 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{ width: `${organization.profileCompleteness}%` }}
+                  />
+                </div>
+                <span className="text-xs font-medium text-text-dark">
+                  {organization.profileCompleteness}%
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4 rounded-lg border border-card-border bg-background p-4">
+            {organization.reviewComment && (
+              <div className="rounded-lg border border-red-100 bg-red-50/80 p-3 text-sm text-red-800">
+                <p className="font-medium">否認理由</p>
+                <p className="mt-1 whitespace-pre-wrap">
+                  {organization.reviewComment}
+                </p>
+              </div>
+            )}
+            {organization.activityAreas.length > 0 && (
+              <div className="flex items-start gap-2 text-sm">
+                <MapPin className="mt-0.5 size-4 shrink-0 text-text-body/60" />
+                <div>
+                  <span className="text-text-body">活動地域:</span>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {organization.activityAreas.map((area) => (
+                      <span
+                        key={area}
+                        className="rounded-full border border-card-border bg-white px-2 py-0.5 text-xs text-text-body"
+                      >
+                        {area}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+            {organization.activityCategories.length > 0 && (
+              <div className="flex items-start gap-2 text-sm">
+                <Tag className="mt-0.5 size-4 shrink-0 text-text-body/60" />
+                <div>
+                  <span className="text-text-body">活動分野:</span>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {organization.activityCategories.map((category) => (
+                      <span
+                        key={category}
+                        className="rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs text-primary"
+                      >
+                        {category}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+            {organization.description && (
+              <div className="flex items-start gap-2 text-sm">
+                <FileText className="mt-0.5 size-4 shrink-0 text-text-body/60" />
+                <div>
+                  <span className="text-text-body">団体説明:</span>
+                  <p className="mt-1 whitespace-pre-wrap leading-6 text-text-dark">
+                    {organization.description}
+                  </p>
+                </div>
+              </div>
+            )}
+            {organization.websiteUrl && (
+              <div className="flex items-center gap-2 text-sm">
+                <Globe className="size-4 shrink-0 text-text-body/60" />
+                <span className="text-text-body">Web:</span>
+                <a
+                  href={organization.websiteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  {organization.websiteUrl}
+                </a>
+              </div>
+            )}
+            {organization.reviewedAt && (
+              <p className="text-xs text-text-body">
+                審査日:{" "}
+                {new Date(organization.reviewedAt).toLocaleDateString("ja-JP")}
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-bold text-text-dark">審査操作</h2>
+        </CardHeader>
+        <CardContent>
+          {isReviewable ? (
+            <>
+              <div className="flex flex-col gap-2 rounded-lg border border-card-border bg-background p-4">
+                <label
+                  htmlFor={`review-comment-${organization.id}`}
+                  className="text-sm font-medium text-text-dark"
+                >
+                  却下理由
+                </label>
+                <textarea
+                  id={`review-comment-${organization.id}`}
+                  value={reviewComment}
+                  onChange={(event) => setReviewComment(event.target.value)}
+                  rows={4}
+                  placeholder="否認する場合は理由を入力してください"
+                  className="w-full rounded-lg border border-input-border bg-white px-3 py-2 text-sm text-text-dark placeholder:text-text-body focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+              </div>
+
+              {feedback && <p className="text-sm text-red-700">{feedback}</p>}
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Button
+                  onClick={handleApprove}
+                  disabled={isPending}
+                  icon={CheckCircle2}
+                  className="flex-1"
+                >
+                  {isPending ? "処理中..." : "承認する"}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleReject}
+                  disabled={isPending || !normalizedComment}
+                  icon={AlertCircle}
+                  className="flex-1 border-red-200 text-red-700 hover:bg-red-50"
+                >
+                  {isPending ? "処理中..." : "否認する"}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              {feedback && <p className="text-sm text-red-700">{feedback}</p>}
+              <Button
+                variant="outline"
+                disabled
+                icon={StatusIcon}
+                className="w-full"
+              >
+                {statusView.label}
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/src/app/admin/reviews/[id]/page.tsx
+++ b/app/src/app/admin/reviews/[id]/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ArrowLeft, Shield } from "lucide-react";
+import { Header } from "@/app/components/Header";
+import { createClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
+import { fetchOrganizationById } from "@/lib/admin/actions";
+import { OrganizationReviewDetail } from "./OrganizationReviewDetail";
+
+export default async function AdminReviewDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  // 管理者チェック
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { role: true },
+  });
+
+  if (!dbUser || dbUser.role !== "admin") {
+    redirect("/forbidden");
+  }
+
+  const organization = await fetchOrganizationById(id);
+
+  if (!organization) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <Link
+          href="/admin/reviews"
+          className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+        >
+          <ArrowLeft className="size-4" />
+          団体審査一覧へ戻る
+        </Link>
+
+        <div className="mb-8 flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+            <Shield className="size-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">
+              団体審査詳細
+            </h1>
+            <p className="text-sm text-text-body">
+              団体情報を確認して承認または否認を行います
+            </p>
+          </div>
+        </div>
+
+        <OrganizationReviewDetail organization={organization} />
+      </main>
+    </div>
+  );
+}

--- a/app/src/lib/admin/actions.test.ts
+++ b/app/src/lib/admin/actions.test.ts
@@ -3,11 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetUser = vi.fn();
 const mockFindUser = vi.fn();
 const mockFindOrganizations = vi.fn();
+const mockFindOrganizationById = vi.fn();
 const mockUpdateOrganization = vi.fn();
 const mockRevalidatePath = vi.fn();
 
 vi.mock("next/cache", () => ({
-  revalidatePath: (path: string) => mockRevalidatePath(path),
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -25,12 +26,18 @@ vi.mock("@/lib/prisma", () => ({
     },
     organizationProfile: {
       findMany: (...args: unknown[]) => mockFindOrganizations(...args),
+      findUnique: (...args: unknown[]) => mockFindOrganizationById(...args),
       update: (...args: unknown[]) => mockUpdateOrganization(...args),
     },
   },
 }));
 
-const { fetchOrganizations, approveOrganization, rejectOrganization } = await import("./actions");
+const {
+  fetchOrganizations,
+  fetchOrganizationById,
+  approveOrganization,
+  rejectOrganization,
+} = await import("./actions");
 
 describe("admin/actions", () => {
   beforeEach(() => {
@@ -73,6 +80,62 @@ describe("admin/actions", () => {
         createdAt: "2026-04-17T10:00:00.000Z",
       }),
     ]);
+  });
+
+  it("単一団体取得時に管理者以外はエラーにする", async () => {
+    mockFindUser.mockResolvedValue({ role: "participant" });
+
+    await expect(fetchOrganizationById("org-1")).rejects.toThrow(
+      "管理者権限が必要です"
+    );
+    expect(mockFindOrganizationById).not.toHaveBeenCalled();
+  });
+
+  it("単一団体取得時に存在する団体を整形して返す", async () => {
+    mockFindOrganizationById.mockResolvedValue({
+      id: "org-1",
+      userId: "user-1",
+      organizationName: "テスト団体",
+      representativeName: "担当者",
+      contactEmail: "org@example.com",
+      activityAreas: ["東京都"],
+      description: "説明",
+      activityCategories: ["子ども支援"],
+      websiteUrl: "https://example.com",
+      profileCompleteness: 80,
+      reviewStatus: "pending",
+      reviewComment: null,
+      reviewedAt: null,
+      reviewedBy: null,
+      verified: false,
+      createdAt: new Date("2026-04-17T10:00:00.000Z"),
+    });
+
+    const result = await fetchOrganizationById("org-1");
+
+    expect(mockFindOrganizationById).toHaveBeenCalledWith({
+      where: { id: "org-1" },
+      select: expect.objectContaining({
+        id: true,
+        reviewStatus: true,
+        createdAt: true,
+      }),
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "org-1",
+        activityAreas: ["東京都"],
+        activityCategories: ["子ども支援"],
+        reviewedAt: null,
+        createdAt: "2026-04-17T10:00:00.000Z",
+      })
+    );
+  });
+
+  it("単一団体取得時に存在しない団体は null を返す", async () => {
+    mockFindOrganizationById.mockResolvedValue(null);
+
+    await expect(fetchOrganizationById("missing-org")).resolves.toBeNull();
   });
 
   it("承認時に承認状態と監査情報を更新する", async () => {

--- a/app/src/lib/admin/actions.ts
+++ b/app/src/lib/admin/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import type { Prisma } from "@/generated/prisma/client";
 import { createClient } from "@/lib/supabase/server";
 import { prisma } from "@/lib/prisma";
 
@@ -48,47 +49,76 @@ export interface PendingOrganization {
   createdAt: string;
 }
 
+const organizationReviewSelect = {
+  id: true,
+  userId: true,
+  organizationName: true,
+  representativeName: true,
+  contactEmail: true,
+  activityAreas: true,
+  description: true,
+  activityCategories: true,
+  websiteUrl: true,
+  profileCompleteness: true,
+  reviewStatus: true,
+  reviewComment: true,
+  reviewedAt: true,
+  reviewedBy: true,
+  verified: true,
+  createdAt: true,
+} satisfies Prisma.OrganizationProfileSelect;
+
+type OrganizationReviewRecord = Prisma.OrganizationProfileGetPayload<{
+  select: typeof organizationReviewSelect;
+}>;
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function mapPendingOrganization(
+  org: OrganizationReviewRecord
+): PendingOrganization {
+  return {
+    ...org,
+    activityAreas: toStringArray(org.activityAreas),
+    activityCategories: toStringArray(org.activityCategories),
+    reviewedAt: org.reviewedAt?.toISOString() ?? null,
+    createdAt: org.createdAt.toISOString(),
+  };
+}
+
 export async function fetchOrganizations(): Promise<PendingOrganization[]> {
   await requireAdmin();
 
   const orgs = await prisma.organizationProfile.findMany({
     orderBy: [{ verified: "asc" }, { createdAt: "desc" }],
-    select: {
-      id: true,
-      userId: true,
-      organizationName: true,
-      representativeName: true,
-      contactEmail: true,
-      activityAreas: true,
-      description: true,
-      activityCategories: true,
-      websiteUrl: true,
-      profileCompleteness: true,
-      reviewStatus: true,
-      reviewComment: true,
-      reviewedAt: true,
-      reviewedBy: true,
-      verified: true,
-      createdAt: true,
-    },
+    select: organizationReviewSelect,
   });
 
-  return orgs.map((org) => ({
-    ...org,
-    activityAreas: Array.isArray(org.activityAreas)
-      ? (org.activityAreas as string[])
-      : [],
-    activityCategories: Array.isArray(org.activityCategories)
-      ? (org.activityCategories as string[])
-      : [],
-    reviewedAt: org.reviewedAt?.toISOString() ?? null,
-    createdAt: org.createdAt.toISOString(),
-  }));
+  return orgs.map(mapPendingOrganization);
+}
+
+/** 審査対象の団体を1件取得する */
+export async function fetchOrganizationById(
+  orgId: string
+): Promise<PendingOrganization | null> {
+  await requireAdmin();
+
+  const org = await prisma.organizationProfile.findUnique({
+    where: { id: orgId },
+    select: organizationReviewSelect,
+  });
+
+  return org ? mapPendingOrganization(org) : null;
 }
 
 function revalidateAdminReviewViews() {
   revalidatePath("/admin/organizations");
   revalidatePath("/admin/reviews");
+  revalidatePath("/admin/reviews/[id]", "page");
   revalidatePath("/onboarding/pending");
   revalidatePath("/dashboard");
 }


### PR DESCRIPTION
## Summary

- `/admin/reviews/[id]` の団体審査詳細ページを追加
- 単一団体取得 action と詳細画面向けの承認/否認 UI を実装
- 一覧から詳細画面への導線と action/UI テストを追加

## Verification

- `cd app && npm run test`: 成功（43 files / 286 tests）
- `cd app && npm run lint`: 成功（既存の `src/lib/dashboard/update-opportunity.test.ts` warning 1件あり）
- `cd app && npm run build`: 成功

## Notes

- 既存の未コミット差分 `.codex/config.toml` は commit 対象外
- Build 中に既存の `/diagnosis/result` dynamic server usage ログが出るが、Next.js は dynamic route として処理し build は成功

Closes #130