### PR TITLE
feat: 管理者ユーザー一覧を追加

### DIFF
--- a/app/src/app/admin/users/AdminUserList.test.tsx
+++ b/app/src/app/admin/users/AdminUserList.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AdminUserList } from "./AdminUserList";
+import type { AdminUserListItem } from "@/lib/admin/actions";
+
+const users: AdminUserListItem[] = [
+  {
+    id: "participant-1",
+    role: "participant",
+    displayName: "参加者 太郎",
+    email: "participant@example.com",
+    avatarUrl: null,
+    isActive: true,
+    region: "東京都",
+    organizationVerified: null,
+    lastLoginAt: "2026-06-19T10:00:00.000Z",
+    createdAt: "2026-06-18T10:00:00.000Z",
+  },
+  {
+    id: "organization-1",
+    role: "organization",
+    displayName: "テスト団体",
+    email: "org@example.com",
+    avatarUrl: null,
+    isActive: false,
+    region: null,
+    organizationVerified: true,
+    lastLoginAt: null,
+    createdAt: "2026-06-17T10:00:00.000Z",
+  },
+  {
+    id: "admin-1",
+    role: "admin",
+    displayName: "管理者",
+    email: "admin@example.com",
+    avatarUrl: null,
+    isActive: true,
+    region: null,
+    organizationVerified: null,
+    lastLoginAt: null,
+    createdAt: "2026-06-16T10:00:00.000Z",
+  },
+];
+
+describe("AdminUserList", () => {
+  it("名前とメールでユーザーを検索できる", () => {
+    render(<AdminUserList users={users} />);
+
+    fireEvent.change(screen.getByLabelText("検索"), {
+      target: { value: "ORG@" },
+    });
+
+    expect(screen.getByText("テスト団体")).toBeDefined();
+    expect(screen.queryByText("参加者 太郎")).toBeNull();
+    expect(screen.queryByText("admin@example.com")).toBeNull();
+  });
+
+  it("ロールタブで表示対象を絞り込める", () => {
+    render(<AdminUserList users={users} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /団体\s+1/ }));
+
+    expect(screen.getByText("テスト団体")).toBeDefined();
+    expect(screen.queryByText("参加者 太郎")).toBeNull();
+    expect(screen.queryByText("admin@example.com")).toBeNull();
+  });
+
+  it("停止中ユーザーは状態バッジのみ表示し、凍結操作は表示しない", () => {
+    render(<AdminUserList users={users} />);
+
+    expect(screen.getByText("停止中")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "停止する" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "解除する" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "凍結する" })).toBeNull();
+  });
+});

--- a/app/src/app/admin/users/AdminUserList.tsx
+++ b/app/src/app/admin/users/AdminUserList.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import {
+  BadgeCheck,
+  Building2,
+  CalendarDays,
+  Mail,
+  MapPin,
+  Search,
+  Shield,
+  User,
+  Users,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { Card, CardContent } from "@/app/components/ui/Card";
+import { Input } from "@/app/components/ui/Input";
+import type { AdminUserListItem } from "@/lib/admin/actions";
+
+interface Props {
+  users: AdminUserListItem[];
+}
+
+type RoleFilter = AdminUserListItem["role"] | "all";
+
+interface RoleView {
+  icon: LucideIcon;
+  label: string;
+  avatarClass: string;
+  badgeClass: string;
+}
+
+const roleViews: Record<AdminUserListItem["role"], RoleView> = {
+  participant: {
+    icon: User,
+    label: "参加者",
+    avatarClass: "bg-primary/10 text-primary",
+    badgeClass: "border-primary/20 bg-primary/5 text-primary",
+  },
+  organization: {
+    icon: Building2,
+    label: "団体",
+    avatarClass: "bg-background text-text-dark",
+    badgeClass: "border-card-border bg-background text-text-dark",
+  },
+  admin: {
+    icon: Shield,
+    label: "管理者",
+    avatarClass: "bg-primary/15 text-primary-dark",
+    badgeClass: "border-primary/30 bg-primary/10 text-primary-dark",
+  },
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString("ja-JP");
+}
+
+function getRoleCount(
+  users: AdminUserListItem[],
+  role: AdminUserListItem["role"]
+) {
+  return users.filter((user) => user.role === role).length;
+}
+
+export function AdminUserList({ users }: Props) {
+  const [query, setQuery] = useState("");
+  const [activeTab, setActiveTab] = useState<RoleFilter>("all");
+
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  const filteredUsers = users.filter((user) => {
+    const matchesRole = activeTab === "all" || user.role === activeTab;
+    const matchesQuery =
+      normalizedQuery.length === 0 ||
+      user.displayName.toLocaleLowerCase().includes(normalizedQuery) ||
+      (user.email?.toLocaleLowerCase().includes(normalizedQuery) ?? false);
+
+    return matchesRole && matchesQuery;
+  });
+
+  const tabs: { key: RoleFilter; label: string; count: number }[] = [
+    { key: "all", label: "すべて", count: users.length },
+    { key: "participant", label: "参加者", count: getRoleCount(users, "participant") },
+    { key: "organization", label: "団体", count: getRoleCount(users, "organization") },
+    { key: "admin", label: "管理者", count: getRoleCount(users, "admin") },
+  ];
+
+  const emptyMessage =
+    normalizedQuery.length > 0
+      ? "条件に一致するユーザーはありません"
+      : activeTab === "participant"
+        ? "参加者は登録されていません"
+        : activeTab === "organization"
+          ? "団体は登録されていません"
+          : activeTab === "admin"
+            ? "管理者は登録されていません"
+            : "登録ユーザーはありません";
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Input
+        id="admin-user-search"
+        label="検索"
+        icon={Search}
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="名前またはメールで検索"
+      />
+
+      <div className="grid grid-cols-2 gap-2 rounded-lg bg-tab-bg p-1 sm:grid-cols-4">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => setActiveTab(tab.key)}
+            className={`flex min-h-10 cursor-pointer items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+              activeTab === tab.key
+                ? "bg-white text-text-dark shadow-sm"
+                : "text-text-body hover:text-text-dark"
+            }`}
+          >
+            <span>{tab.label}</span>
+            <span
+              className={`rounded-full px-1.5 py-0.5 text-xs ${
+                activeTab === tab.key
+                  ? "bg-primary/10 text-primary"
+                  : "bg-white/60 text-text-body"
+              }`}
+            >
+              {tab.count}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {filteredUsers.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-12 text-center">
+          <Users className="size-10 text-text-body/30" />
+          <p className="text-sm text-text-body">{emptyMessage}</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {filteredUsers.map((user) => {
+            const roleView = roleViews[user.role];
+            const RoleIcon = roleView.icon;
+
+            return (
+              <Card key={user.id}>
+                <CardContent className="gap-4">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <div
+                        className={`flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-full ${roleView.avatarClass}`}
+                        aria-label={`${user.displayName}のアバター`}
+                        style={
+                          user.avatarUrl
+                            ? {
+                                backgroundImage: `url("${user.avatarUrl}")`,
+                                backgroundPosition: "center",
+                                backgroundSize: "cover",
+                              }
+                            : undefined
+                        }
+                      >
+                        {!user.avatarUrl && <RoleIcon className="size-5" />}
+                      </div>
+                      <div className="min-w-0">
+                        <h2 className="break-words text-base font-bold text-text-dark">
+                          {user.displayName}
+                        </h2>
+                        <div className="mt-1 flex items-center gap-1.5 text-sm text-text-body">
+                          <Mail className="size-4 shrink-0 text-text-body/60" />
+                          <span className="break-all">
+                            {user.email ?? "メール未設定"}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2 sm:justify-end">
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium ${roleView.badgeClass}`}
+                      >
+                        <RoleIcon className="size-3.5" />
+                        {roleView.label}
+                      </span>
+                      {!user.isActive && (
+                        <span className="inline-flex items-center gap-1 rounded-full border border-card-border bg-background px-2.5 py-1 text-xs font-medium text-text-body">
+                          <XCircle className="size-3.5" />
+                          停止中
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3 text-sm text-text-body sm:grid-cols-2">
+                    {user.role === "participant" && user.region && (
+                      <div className="flex items-center gap-2">
+                        <MapPin className="size-4 shrink-0 text-text-body/60" />
+                        <span>地域: {user.region}</span>
+                      </div>
+                    )}
+                    {user.role === "organization" && (
+                      <div className="flex items-center gap-2">
+                        <BadgeCheck className="size-4 shrink-0 text-text-body/60" />
+                        <span>
+                          {user.organizationVerified
+                            ? "認証済み"
+                            : "未認証"}
+                        </span>
+                      </div>
+                    )}
+                    <div className="flex items-center gap-2">
+                      <CalendarDays className="size-4 shrink-0 text-text-body/60" />
+                      <span>登録日: {formatDate(user.createdAt)}</span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/app/admin/users/page.tsx
+++ b/app/src/app/admin/users/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from "next/navigation";
+import { Users } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
+import { Header } from "@/app/components/Header";
+import { fetchUsers } from "@/lib/admin/actions";
+import { AdminUserList } from "./AdminUserList";
+
+export default async function AdminUsersPage() {
+  // 管理者チェック
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { role: true },
+  });
+
+  if (!dbUser || dbUser.role !== "admin") {
+    redirect("/forbidden");
+  }
+
+  const users = await fetchUsers();
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <div className="mb-8 flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+            <Users className="size-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">
+              ユーザー一覧
+            </h1>
+            <p className="text-sm text-text-body">
+              登録ユーザーの検索・確認を行います
+            </p>
+          </div>
+        </div>
+
+        <AdminUserList users={users} />
+      </main>
+    </div>
+  );
+}

--- a/app/src/lib/admin/actions.test.ts
+++ b/app/src/lib/admin/actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetUser = vi.fn();
 const mockFindUser = vi.fn();
+const mockFindUsers = vi.fn();
 const mockFindOrganizations = vi.fn();
 const mockUpdateOrganization = vi.fn();
 const mockRevalidatePath = vi.fn();
@@ -22,6 +23,7 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     user: {
       findUnique: (...args: unknown[]) => mockFindUser(...args),
+      findMany: (...args: unknown[]) => mockFindUsers(...args),
     },
     organizationProfile: {
       findMany: (...args: unknown[]) => mockFindOrganizations(...args),
@@ -30,7 +32,7 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
-const { fetchOrganizations, approveOrganization, rejectOrganization } = await import("./actions");
+const { fetchUsers, fetchOrganizations, approveOrganization, rejectOrganization } = await import("./actions");
 
 describe("admin/actions", () => {
   beforeEach(() => {
@@ -73,6 +75,151 @@ describe("admin/actions", () => {
         createdAt: "2026-04-17T10:00:00.000Z",
       }),
     ]);
+  });
+
+  it("ユーザー一覧取得時にロール別の補助情報と日付を整形する", async () => {
+    mockFindUsers.mockResolvedValue([
+      {
+        id: "participant-1",
+        role: "participant",
+        email: "participant@example.com",
+        name: "  ",
+        avatarUrl: null,
+        isActive: true,
+        lastLoginAt: new Date("2026-06-19T10:00:00.000Z"),
+        createdAt: new Date("2026-06-18T10:00:00.000Z"),
+        participantProfile: {
+          name: "参加者 太郎",
+          region: "東京都",
+        },
+        organizationProfile: null,
+      },
+      {
+        id: "organization-1",
+        role: "organization",
+        email: "org@example.com",
+        name: null,
+        avatarUrl: "https://example.com/avatar.png",
+        isActive: false,
+        lastLoginAt: null,
+        createdAt: new Date("2026-06-17T10:00:00.000Z"),
+        participantProfile: null,
+        organizationProfile: {
+          organizationName: "テスト団体",
+          verified: true,
+        },
+      },
+      {
+        id: "admin-1",
+        role: "admin",
+        email: null,
+        name: "管理者",
+        avatarUrl: null,
+        isActive: true,
+        lastLoginAt: null,
+        createdAt: new Date("2026-06-16T10:00:00.000Z"),
+        participantProfile: null,
+        organizationProfile: null,
+      },
+    ]);
+
+    const result = await fetchUsers();
+
+    expect(mockFindUsers).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        role: true,
+        email: true,
+        name: true,
+        avatarUrl: true,
+        isActive: true,
+        lastLoginAt: true,
+        createdAt: true,
+        participantProfile: {
+          select: { name: true, region: true },
+        },
+        organizationProfile: {
+          select: { organizationName: true, verified: true },
+        },
+      },
+    });
+    expect(result).toEqual([
+      {
+        id: "participant-1",
+        role: "participant",
+        displayName: "参加者 太郎",
+        email: "participant@example.com",
+        avatarUrl: null,
+        isActive: true,
+        region: "東京都",
+        organizationVerified: null,
+        lastLoginAt: "2026-06-19T10:00:00.000Z",
+        createdAt: "2026-06-18T10:00:00.000Z",
+      },
+      {
+        id: "organization-1",
+        role: "organization",
+        displayName: "テスト団体",
+        email: "org@example.com",
+        avatarUrl: "https://example.com/avatar.png",
+        isActive: false,
+        region: null,
+        organizationVerified: true,
+        lastLoginAt: null,
+        createdAt: "2026-06-17T10:00:00.000Z",
+      },
+      {
+        id: "admin-1",
+        role: "admin",
+        displayName: "管理者",
+        email: null,
+        avatarUrl: null,
+        isActive: true,
+        region: null,
+        organizationVerified: null,
+        lastLoginAt: null,
+        createdAt: "2026-06-16T10:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("ユーザー名とプロフィール名が空なら未設定表示にフォールバックする", async () => {
+    mockFindUsers.mockResolvedValue([
+      {
+        id: "participant-1",
+        role: "participant",
+        email: "participant@example.com",
+        name: " ",
+        avatarUrl: null,
+        isActive: true,
+        lastLoginAt: null,
+        createdAt: new Date("2026-06-18T10:00:00.000Z"),
+        participantProfile: {
+          name: "",
+          region: "東京都",
+        },
+        organizationProfile: null,
+      },
+    ]);
+
+    const result = await fetchUsers();
+
+    expect(result[0]?.displayName).toBe("(名前未設定)");
+  });
+
+  it("非管理者はユーザー一覧を取得できない", async () => {
+    mockFindUser.mockResolvedValue({ role: "participant" });
+
+    await expect(fetchUsers()).rejects.toThrow("管理者権限が必要です");
+    expect(mockFindUsers).not.toHaveBeenCalled();
+  });
+
+  it("未ログインではユーザー一覧を取得できない", async () => {
+    mockGetUser.mockReturnValue({ data: { user: null } });
+
+    await expect(fetchUsers()).rejects.toThrow("認証が必要です");
+    expect(mockFindUsers).not.toHaveBeenCalled();
   });
 
   it("承認時に承認状態と監査情報を更新する", async () => {

--- a/app/src/lib/admin/actions.ts
+++ b/app/src/lib/admin/actions.ts
@@ -48,6 +48,80 @@ export interface PendingOrganization {
   createdAt: string;
 }
 
+export interface AdminUserListItem {
+  id: string;
+  role: "participant" | "organization" | "admin";
+  displayName: string;
+  email: string | null;
+  avatarUrl: string | null;
+  isActive: boolean;
+  region: string | null;
+  organizationVerified: boolean | null;
+  lastLoginAt: string | null;
+  createdAt: string;
+}
+
+function resolveDisplayName(
+  userName: string | null,
+  participantName: string | null | undefined,
+  organizationName: string | null | undefined
+) {
+  return (
+    userName?.trim() ||
+    participantName?.trim() ||
+    organizationName?.trim() ||
+    "(名前未設定)"
+  );
+}
+
+/** 登録ユーザー一覧を取得する */
+export async function fetchUsers(): Promise<AdminUserListItem[]> {
+  await requireAdmin();
+
+  const users = await prisma.user.findMany({
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      role: true,
+      email: true,
+      name: true,
+      avatarUrl: true,
+      isActive: true,
+      lastLoginAt: true,
+      createdAt: true,
+      participantProfile: {
+        select: { name: true, region: true },
+      },
+      organizationProfile: {
+        select: { organizationName: true, verified: true },
+      },
+    },
+  });
+
+  return users.map((user) => ({
+    id: user.id,
+    role: user.role,
+    displayName: resolveDisplayName(
+      user.name,
+      user.participantProfile?.name,
+      user.organizationProfile?.organizationName
+    ),
+    email: user.email,
+    avatarUrl: user.avatarUrl,
+    isActive: user.isActive,
+    region:
+      user.role === "participant"
+        ? user.participantProfile?.region ?? null
+        : null,
+    organizationVerified:
+      user.role === "organization"
+        ? user.organizationProfile?.verified ?? null
+        : null,
+    lastLoginAt: user.lastLoginAt?.toISOString() ?? null,
+    createdAt: user.createdAt.toISOString(),
+  }));
+}
+
 export async function fetchOrganizations(): Promise<PendingOrganization[]> {
   await requireAdmin();
 


### PR DESCRIPTION
## Summary

- `/admin/users` ページを追加し、admin 認可後にユーザー一覧を表示
- `fetchUsers()` Server Action を追加し、参加者・団体・管理者の表示名、補助情報、日付を整形
- 検索、ロールタブ、停止中バッジを備えた `AdminUserList` とテストを追加

## Verification

- `cd app && npm run test -- admin`: 成功（2 files / 11 tests）
- `cd app && npx tsc --noEmit --pretty false`: 成功
- `cd app && npm run lint`: 成功（既存の `src/lib/dashboard/update-opportunity.test.ts` warning 1 件あり）
- `cd app && npm run build`: 成功（既存の `/diagnosis/result` dynamic server usage ログと baseline-browser-mapping warning あり）

## Notes

- 凍結/解除操作は #132 の対象外として追加していません。`isActive` は状態バッジのみ表示します。
- Closes #132