### PR TITLE
feat: 審査履歴画面を追加

### DIFF
--- a/app/src/app/admin/reviews/history/ReviewHistoryList.tsx
+++ b/app/src/app/admin/reviews/history/ReviewHistoryList.tsx
@@ -1,0 +1,113 @@
+import {
+  Building2,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  UserRound,
+  XCircle,
+} from "lucide-react";
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import type { ReviewHistoryEntry } from "@/lib/admin/actions";
+
+interface Props {
+  entries: ReviewHistoryEntry[];
+}
+
+function getStatusView(status: ReviewHistoryEntry["reviewStatus"]) {
+  if (status === "approved") {
+    return {
+      icon: CheckCircle2,
+      label: "承認済み",
+      chipClass: "border-green-200 bg-green-50 text-green-700",
+      iconClass: "text-green-600",
+      avatarClass: "bg-green-50",
+    };
+  }
+
+  return {
+    icon: XCircle,
+    label: "否認済み",
+    chipClass: "border-red-200 bg-red-50 text-red-700",
+    iconClass: "text-red-600",
+    avatarClass: "bg-red-50",
+  };
+}
+
+function formatReviewedAt(reviewedAt: string) {
+  return new Date(reviewedAt).toLocaleString("ja-JP");
+}
+
+export function ReviewHistoryList({ entries }: Props) {
+  if (entries.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-12 text-center">
+        <FileText className="size-10 text-text-body/30" />
+        <p className="text-sm text-text-body">審査履歴がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {entries.map((entry) => {
+        const statusView = getStatusView(entry.reviewStatus);
+        const StatusIcon = statusView.icon;
+
+        return (
+          <Card key={entry.id}>
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <div
+                    className={`flex size-10 items-center justify-center rounded-full ${statusView.avatarClass}`}
+                  >
+                    <Building2 className={`size-5 ${statusView.iconClass}`} />
+                  </div>
+                  <div>
+                    <h3 className="text-base font-bold text-text-dark">
+                      {entry.organizationName}
+                    </h3>
+                    <p className="text-xs text-text-body">
+                      審査日: {formatReviewedAt(entry.reviewedAt)}
+                    </p>
+                  </div>
+                </div>
+                <span
+                  className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium ${statusView.chipClass}`}
+                >
+                  <StatusIcon className="size-3.5" />
+                  {statusView.label}
+                </span>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="flex items-center gap-2 text-sm">
+                  <CalendarClock className="size-4 shrink-0 text-text-body/60" />
+                  <span className="text-text-body">審査日時:</span>
+                  <span className="font-medium text-text-dark">
+                    {formatReviewedAt(entry.reviewedAt)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <UserRound className="size-4 shrink-0 text-text-body/60" />
+                  <span className="text-text-body">審査者:</span>
+                  <span className="font-medium text-text-dark">
+                    {entry.reviewerName ?? "不明"}
+                  </span>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-card-border bg-background p-4 text-sm">
+                <p className="font-medium text-text-dark">理由</p>
+                <p className="mt-2 whitespace-pre-wrap text-text-body">
+                  {entry.reviewComment ?? "理由なし"}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/app/admin/reviews/history/page.tsx
+++ b/app/src/app/admin/reviews/history/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import { Shield } from "lucide-react";
+import { Header } from "@/app/components/Header";
+import { ReviewHistoryList } from "@/app/admin/reviews/history/ReviewHistoryList";
+import { fetchReviewHistory } from "@/lib/admin/actions";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function AdminReviewHistoryPage() {
+  // 管理者チェック
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { role: true },
+  });
+
+  if (!dbUser || dbUser.role !== "admin") {
+    redirect("/forbidden");
+  }
+
+  const history = await fetchReviewHistory();
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-8">
+        <div className="mb-8 flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-full bg-primary/10">
+            <Shield className="size-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">審査履歴</h1>
+            <p className="text-sm text-text-body">
+              過去の承認・却下の履歴を確認できます
+            </p>
+          </div>
+        </div>
+
+        <ReviewHistoryList entries={history} />
+      </main>
+    </div>
+  );
+}

--- a/app/src/lib/admin/actions.test.ts
+++ b/app/src/lib/admin/actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetUser = vi.fn();
 const mockFindUser = vi.fn();
+const mockFindUsers = vi.fn();
 const mockFindOrganizations = vi.fn();
 const mockUpdateOrganization = vi.fn();
 const mockRevalidatePath = vi.fn();
@@ -22,6 +23,7 @@ vi.mock("@/lib/prisma", () => ({
   prisma: {
     user: {
       findUnique: (...args: unknown[]) => mockFindUser(...args),
+      findMany: (...args: unknown[]) => mockFindUsers(...args),
     },
     organizationProfile: {
       findMany: (...args: unknown[]) => mockFindOrganizations(...args),
@@ -30,7 +32,12 @@ vi.mock("@/lib/prisma", () => ({
   },
 }));
 
-const { fetchOrganizations, approveOrganization, rejectOrganization } = await import("./actions");
+const {
+  fetchOrganizations,
+  fetchReviewHistory,
+  approveOrganization,
+  rejectOrganization,
+} = await import("./actions");
 
 describe("admin/actions", () => {
   beforeEach(() => {
@@ -73,6 +80,122 @@ describe("admin/actions", () => {
         createdAt: "2026-04-17T10:00:00.000Z",
       }),
     ]);
+  });
+
+  it("審査履歴取得時に承認・否認済み団体を審査日時順で整形する", async () => {
+    mockFindOrganizations.mockResolvedValue([
+      {
+        id: "org-2",
+        organizationName: "承認済み団体",
+        reviewStatus: "approved",
+        reviewComment: null,
+        reviewedAt: new Date("2026-04-19T09:00:00.000Z"),
+        reviewedBy: "admin-2",
+      },
+      {
+        id: "org-1",
+        organizationName: "否認済み団体",
+        reviewStatus: "rejected",
+        reviewComment: "活動内容を補足してください",
+        reviewedAt: new Date("2026-04-18T10:00:00.000Z"),
+        reviewedBy: "admin-1",
+      },
+    ]);
+    mockFindUsers.mockResolvedValue([
+      { id: "admin-1", name: "管理者 一郎" },
+      { id: "admin-2", name: "管理者 二郎" },
+    ]);
+
+    const result = await fetchReviewHistory();
+
+    expect(mockFindOrganizations).toHaveBeenCalledWith({
+      where: {
+        reviewStatus: { in: ["approved", "rejected"] },
+        reviewedAt: { not: null },
+      },
+      orderBy: { reviewedAt: "desc" },
+      select: {
+        id: true,
+        organizationName: true,
+        reviewStatus: true,
+        reviewComment: true,
+        reviewedAt: true,
+        reviewedBy: true,
+      },
+    });
+    expect(mockFindUsers).toHaveBeenCalledWith({
+      where: { id: { in: ["admin-2", "admin-1"] } },
+      select: { id: true, name: true },
+    });
+    expect(result).toEqual([
+      {
+        id: "org-2",
+        organizationName: "承認済み団体",
+        reviewStatus: "approved",
+        reviewComment: null,
+        reviewedAt: "2026-04-19T09:00:00.000Z",
+        reviewedBy: "admin-2",
+        reviewerName: "管理者 二郎",
+      },
+      {
+        id: "org-1",
+        organizationName: "否認済み団体",
+        reviewStatus: "rejected",
+        reviewComment: "活動内容を補足してください",
+        reviewedAt: "2026-04-18T10:00:00.000Z",
+        reviewedBy: "admin-1",
+        reviewerName: "管理者 一郎",
+      },
+    ]);
+  });
+
+  it("審査者名を解決できない履歴は reviewerName を null にする", async () => {
+    mockFindOrganizations.mockResolvedValue([
+      {
+        id: "org-1",
+        organizationName: "審査者不明団体",
+        reviewStatus: "rejected",
+        reviewComment: "確認できません",
+        reviewedAt: new Date("2026-04-18T10:00:00.000Z"),
+        reviewedBy: "missing-admin",
+      },
+      {
+        id: "org-2",
+        organizationName: "移行データ団体",
+        reviewStatus: "approved",
+        reviewComment: null,
+        reviewedAt: new Date("2026-04-17T10:00:00.000Z"),
+        reviewedBy: null,
+      },
+    ]);
+    mockFindUsers.mockResolvedValue([]);
+
+    const result = await fetchReviewHistory();
+
+    expect(mockFindUsers).toHaveBeenCalledWith({
+      where: { id: { in: ["missing-admin"] } },
+      select: { id: true, name: true },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "org-1",
+        reviewedBy: "missing-admin",
+        reviewerName: null,
+      }),
+      expect.objectContaining({
+        id: "org-2",
+        reviewedBy: null,
+        reviewerName: null,
+      }),
+    ]);
+  });
+
+  it("非管理者は審査履歴を取得できない", async () => {
+    mockFindUser.mockResolvedValue({ role: "participant" });
+
+    await expect(fetchReviewHistory()).rejects.toThrow("管理者権限が必要です");
+    expect(mockFindOrganizations).not.toHaveBeenCalled();
+    expect(mockFindUsers).not.toHaveBeenCalled();
   });
 
   it("承認時に承認状態と監査情報を更新する", async () => {

--- a/app/src/lib/admin/actions.ts
+++ b/app/src/lib/admin/actions.ts
@@ -48,6 +48,17 @@ export interface PendingOrganization {
   createdAt: string;
 }
 
+/** 審査履歴の 1 エントリ */
+export interface ReviewHistoryEntry {
+  id: string;
+  organizationName: string;
+  reviewStatus: "approved" | "rejected";
+  reviewComment: string | null;
+  reviewedAt: string;
+  reviewedBy: string | null;
+  reviewerName: string | null;
+}
+
 export async function fetchOrganizations(): Promise<PendingOrganization[]> {
   await requireAdmin();
 
@@ -86,9 +97,68 @@ export async function fetchOrganizations(): Promise<PendingOrganization[]> {
   }));
 }
 
+/** 承認・否認済みの審査履歴を取得する */
+export async function fetchReviewHistory(): Promise<ReviewHistoryEntry[]> {
+  await requireAdmin();
+
+  const histories = await prisma.organizationProfile.findMany({
+    where: {
+      reviewStatus: { in: ["approved", "rejected"] },
+      reviewedAt: { not: null },
+    },
+    orderBy: { reviewedAt: "desc" },
+    select: {
+      id: true,
+      organizationName: true,
+      reviewStatus: true,
+      reviewComment: true,
+      reviewedAt: true,
+      reviewedBy: true,
+    },
+  });
+
+  const reviewerIds = Array.from(
+    new Set(
+      histories
+        .map((history) => history.reviewedBy)
+        .filter((reviewedBy): reviewedBy is string => reviewedBy !== null)
+    )
+  );
+
+  const reviewers =
+    reviewerIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: reviewerIds } },
+          select: { id: true, name: true },
+        })
+      : [];
+  const reviewerNameMap = new Map(
+    reviewers.map((reviewer) => [reviewer.id, reviewer.name])
+  );
+
+  return histories.map((history) => {
+    if (!history.reviewedAt) {
+      throw new Error("審査日時がない履歴は表示できません");
+    }
+
+    return {
+      id: history.id,
+      organizationName: history.organizationName,
+      reviewStatus: history.reviewStatus as ReviewHistoryEntry["reviewStatus"],
+      reviewComment: history.reviewComment,
+      reviewedAt: history.reviewedAt.toISOString(),
+      reviewedBy: history.reviewedBy,
+      reviewerName: history.reviewedBy
+        ? (reviewerNameMap.get(history.reviewedBy) ?? null)
+        : null,
+    };
+  });
+}
+
 function revalidateAdminReviewViews() {
   revalidatePath("/admin/organizations");
   revalidatePath("/admin/reviews");
+  revalidatePath("/admin/reviews/history");
   revalidatePath("/onboarding/pending");
   revalidatePath("/dashboard");
 }


### PR DESCRIPTION
## Summary

- `/admin/reviews/history` に管理者向けの審査履歴ページを追加
- 承認・否認済み団体を `OrganizationProfile` から取得する `fetchReviewHistory` を追加
- 審査者名の解決、理由表示、空状態、履歴ページの revalidate を追加
- Closes #131

## Verification

- `npx vitest run src/lib/admin/actions.test.ts`: 成功
- `npm run lint`: 成功（既存 warning: `src/lib/dashboard/update-opportunity.test.ts` の未使用引数）
- `npm run test`: 成功（42 files / 283 tests）
- `npm run build`: 成功

## Notes

- スキーマ変更・マイグレーションはありません。
- `.codex/config.toml` の既存未コミット変更は PR に含めていません。