### PR TITLE
feat: LINE友だち追加連携を強化

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,6 +19,7 @@
         "next": "^16.1.6",
         "pdf-lib": "^1.17.1",
         "pg": "^8.20.0",
+        "qrcode": "^1.5.4",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "xstate": "^5.24.0"
@@ -29,6 +30,7 @@
         "@testing-library/react": "^16.3.0",
         "@types/node": "^20",
         "@types/pg": "^8.20.0",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4.7.0",
@@ -3189,6 +3191,16 @@
       "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
@@ -3992,7 +4004,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4001,7 +4012,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4486,6 +4496,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001754",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
@@ -4593,11 +4612,21 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4610,7 +4639,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -4798,6 +4826,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -4908,6 +4945,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6006,6 +6049,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6636,6 +6688,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -7950,6 +8011,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7985,7 +8055,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8183,6 +8252,15 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -8410,6 +8488,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8547,6 +8642,15 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8555,6 +8659,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8777,6 +8887,12 @@
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
       "devOptional": true
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9069,6 +9185,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -9180,6 +9316,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -10471,6 +10619,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -10517,6 +10671,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {
@@ -10572,12 +10740,105 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "next": "^16.1.6",
     "pdf-lib": "^1.17.1",
     "pg": "^8.20.0",
+    "qrcode": "^1.5.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "xstate": "^5.24.0"
@@ -39,6 +40,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/node": "^20",
     "@types/pg": "^8.20.0",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.7.0",

--- a/app/src/app/components/LineContactCard.test.tsx
+++ b/app/src/app/components/LineContactCard.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LineContactCard } from "@/app/components/LineContactCard";
+
+describe("LineContactCard", () => {
+  it("友だち追加URLがある場合、ボタン・QR・LINE IDを表示する", async () => {
+    const element = await LineContactCard({
+      addUrl: "https://line.me/R/ti/p/@volunty",
+      displayId: "@volunty",
+    });
+
+    render(element);
+
+    const link = screen.getByRole("link", { name: /友だち追加/ });
+    expect(link.getAttribute("href")).toBe("https://line.me/R/ti/p/@volunty");
+    expect(screen.getByLabelText("LINE友だち追加用QRコード")).toBeDefined();
+    expect(screen.getByText("@volunty")).toBeDefined();
+  });
+
+  it("メールだけがある場合も団体連絡先として表示する", async () => {
+    const element = await LineContactCard({
+      addUrl: null,
+      displayId: null,
+      email: "contact@example.org",
+    });
+
+    render(element);
+
+    expect(screen.getByText("団体連絡先")).toBeDefined();
+    expect(screen.getByText("contact@example.org")).toBeDefined();
+  });
+
+  it("連絡先が無い場合は何も描画しない", async () => {
+    const element = await LineContactCard({
+      addUrl: null,
+      displayId: null,
+      email: null,
+    });
+
+    expect(element).toBeNull();
+  });
+});

--- a/app/src/app/components/LineContactCard.tsx
+++ b/app/src/app/components/LineContactCard.tsx
@@ -1,0 +1,89 @@
+import QRCode from "qrcode";
+import { MessageCircle } from "lucide-react";
+
+import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+
+interface LineContactCardProps {
+  addUrl: string | null;
+  displayId: string | null;
+  email?: string | null;
+}
+
+async function renderQrSvg(url: string): Promise<string | null> {
+  try {
+    return await QRCode.toString(url, {
+      type: "svg",
+      margin: 1,
+      width: 160,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function LineContactCard({
+  addUrl,
+  displayId,
+  email = null,
+}: LineContactCardProps) {
+  if (!addUrl && !displayId && !email) return null;
+
+  const qrSvg = addUrl ? await renderQrSvg(addUrl) : null;
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <MessageCircle className="size-5 text-primary" />
+          <h2 className="text-lg font-bold text-text-dark">団体連絡先</h2>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {addUrl && (
+            <div className="rounded-lg bg-green-50 p-4">
+              <p className="text-xs text-green-700">
+                LINEで友だち追加して連絡できます
+              </p>
+              <div className="mt-3 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+                <a
+                  href={addUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-lg bg-line-green px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-line-green-dark"
+                >
+                  <MessageCircle className="size-4" />
+                  友だち追加
+                </a>
+                {qrSvg && (
+                  <div
+                    className="size-[160px] shrink-0 rounded-lg bg-white p-1"
+                    aria-label="LINE友だち追加用QRコード"
+                    dangerouslySetInnerHTML={{ __html: qrSvg }}
+                  />
+                )}
+              </div>
+              <p className="mt-2 text-xs text-green-700">
+                スマホはボタン、PCは手元のスマホでQRを読み取ってください。
+              </p>
+            </div>
+          )}
+
+          {displayId && (
+            <div className="rounded-lg bg-green-50 p-3">
+              <p className="text-xs text-green-700">LINE ID</p>
+              <p className="mt-1 font-medium text-green-800">{displayId}</p>
+            </div>
+          )}
+
+          {email && (
+            <div className="rounded-lg bg-green-50 p-3">
+              <p className="text-xs text-green-700">メール</p>
+              <p className="mt-1 font-medium text-green-800">{email}</p>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -6,6 +6,8 @@
   --foreground: #6d2700;
   --primary: #fb5b01;
   --primary-dark: #c74700;
+  --line-green: #06c755;
+  --line-green-dark: #05a646;
   --text-dark: #6d2700;
   --text-body: #8b4513;
   --card-border: rgba(203, 71, 0, 0.2);
@@ -20,6 +22,8 @@
   --color-foreground: var(--foreground);
   --color-primary: var(--primary);
   --color-primary-dark: var(--primary-dark);
+  --color-line-green: var(--line-green);
+  --color-line-green-dark: var(--line-green-dark);
   --color-text-dark: var(--text-dark);
   --color-text-body: var(--text-body);
   --color-card-border: var(--card-border);

--- a/app/src/app/mypage/applications/[id]/page.tsx
+++ b/app/src/app/mypage/applications/[id]/page.tsx
@@ -4,7 +4,6 @@ import {
   Clock,
   CheckCircle2,
   XCircle,
-  MessageCircle,
   MessageSquare,
   MapPin,
   Calendar,
@@ -14,7 +13,9 @@ import {
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 import { Header } from "@/app/components/Header";
+import { LineContactCard } from "@/app/components/LineContactCard";
 import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import { buildLineFriendContact } from "@/lib/line/contact";
 import { fetchMyApplicationDetail } from "@/lib/mypage/actions";
 import type { ApplicationStatus } from "@/lib/mypage/types";
 
@@ -80,6 +81,10 @@ export default async function MyApplicationDetailPage({
   }
 
   const display = statusDisplay(application.status);
+  const lineContact = buildLineFriendContact({
+    url: application.opportunity.organization_line_url,
+    id: application.opportunity.organization_line_id,
+  });
 
   return (
     <div className="min-h-screen bg-background font-sans">
@@ -206,26 +211,10 @@ export default async function MyApplicationDetailPage({
           </CardContent>
         </Card>
 
-        {application.opportunity.organization_line_id && (
-          <Card className="mb-6">
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <MessageCircle className="size-5 text-primary" />
-                <h2 className="text-lg font-bold text-text-dark">
-                  団体連絡先
-                </h2>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="rounded-lg bg-green-50 p-3">
-                <p className="text-xs text-green-700">LINE ID</p>
-                <p className="mt-1 font-medium text-green-800">
-                  {application.opportunity.organization_line_id}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+        <LineContactCard
+          addUrl={lineContact.addUrl}
+          displayId={lineContact.displayId}
+        />
 
         {application.can_request_certificate && (
           <Link

--- a/app/src/app/mypage/approaches/[id]/page.test.tsx
+++ b/app/src/app/mypage/approaches/[id]/page.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchMyApproachDetail: vi.fn(),
+  notFound: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    mocks.notFound();
+    throw new Error("NEXT_NOT_FOUND");
+  },
+  redirect: (url: string) => {
+    mocks.redirect(url);
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/components/Header", () => ({
+  Header: () => <header>ヘッダー</header>,
+}));
+
+vi.mock("@/lib/approaches/actions", () => ({
+  fetchMyApproachDetail: (...args: unknown[]) =>
+    mocks.fetchMyApproachDetail(...args),
+}));
+
+vi.mock("./ApproachResponseActions", () => ({
+  ApproachResponseActions: () => <div>回答フォーム</div>,
+}));
+
+import MyApproachDetailPage from "./page";
+
+describe("MyApproachDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchMyApproachDetail.mockResolvedValue({
+      approach: {
+        id: "approach-1",
+        status: "accepted",
+        message: "ぜひ参加してください",
+        matchScore: 92,
+        createdAt: "2026-06-16T10:00:00.000Z",
+        expiresAt: "2026-06-30T00:00:00.000Z",
+        respondedAt: "2026-06-16T11:00:00.000Z",
+        isExpired: false,
+        opportunityId: "opportunity-1",
+        opportunityTitle: "地域イベント運営",
+        organizationName: "テスト団体",
+        contact: {
+          email: "contact@example.org",
+          lineId: "@volunty",
+          lineUrl: "https://line.me/R/ti/p/@volunty",
+        },
+        hasContact: true,
+      },
+      error: undefined,
+    });
+  });
+
+  it("承諾済みアプローチではLINE友だち追加リンクとQRを表示する", async () => {
+    const page = await MyApproachDetailPage({
+      params: Promise.resolve({ id: "approach-1" }),
+    });
+    render(page);
+
+    const link = screen.getByRole("link", { name: /友だち追加/ });
+    expect(link.getAttribute("href")).toBe("https://line.me/R/ti/p/@volunty");
+    expect(screen.getByLabelText("LINE友だち追加用QRコード")).toBeDefined();
+    expect(screen.getByText("@volunty")).toBeDefined();
+    expect(screen.getByText("contact@example.org")).toBeDefined();
+  });
+});

--- a/app/src/app/mypage/approaches/[id]/page.tsx
+++ b/app/src/app/mypage/approaches/[id]/page.tsx
@@ -3,13 +3,14 @@ import {
   ArrowLeft,
   CheckCircle2,
   Clock,
-  MessageCircle,
   MessageSquare,
   XCircle,
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 import { Header } from "@/app/components/Header";
+import { LineContactCard } from "@/app/components/LineContactCard";
 import { Card, CardContent, CardHeader } from "@/app/components/ui/Card";
+import { buildLineFriendContact } from "@/lib/line/contact";
 import { fetchMyApproachDetail } from "@/lib/approaches/actions";
 import type { ApproachStatus } from "@/lib/approaches/types";
 import { ApproachResponseActions } from "./ApproachResponseActions";
@@ -70,6 +71,19 @@ export default async function MyApproachDetailPage({
     approach.status === "accepted" && approach.hasContact
       ? approach.contact
       : null;
+  const lineContact = contact
+    ? buildLineFriendContact({
+        url: contact.lineUrl,
+        id: contact.lineId,
+      })
+    : null;
+  const contactCard = contact ? (
+    await LineContactCard({
+      addUrl: lineContact?.addUrl ?? null,
+      displayId: lineContact?.displayId ?? null,
+      email: contact.email,
+    })
+  ) : null;
 
   return (
     <div className="min-h-screen bg-background font-sans">
@@ -169,53 +183,7 @@ export default async function MyApproachDetailPage({
           </Card>
         )}
 
-        {contact && (
-          <Card className="mb-6">
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <MessageCircle className="size-5 text-primary" />
-                <h2 className="text-lg font-bold text-text-dark">
-                  団体連絡先
-                </h2>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <dl className="space-y-3 text-sm">
-                {contact.lineId && (
-                  <div className="rounded-lg bg-green-50 p-3">
-                    <dt className="text-xs text-green-700">LINE ID</dt>
-                    <dd className="mt-1 font-medium text-green-800">
-                      {contact.lineId}
-                    </dd>
-                  </div>
-                )}
-                {contact.lineUrl && (
-                  <div className="rounded-lg bg-green-50 p-3">
-                    <dt className="text-xs text-green-700">LINE URL</dt>
-                    <dd className="mt-1">
-                      <a
-                        href={contact.lineUrl}
-                        className="font-medium text-green-800 underline"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {contact.lineUrl}
-                      </a>
-                    </dd>
-                  </div>
-                )}
-                {contact.email && (
-                  <div className="rounded-lg bg-green-50 p-3">
-                    <dt className="text-xs text-green-700">メール</dt>
-                    <dd className="mt-1 font-medium text-green-800">
-                      {contact.email}
-                    </dd>
-                  </div>
-                )}
-              </dl>
-            </CardContent>
-          </Card>
-        )}
+        {contactCard}
       </main>
     </div>
   );

--- a/app/src/lib/line/contact.test.ts
+++ b/app/src/lib/line/contact.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildLineFriendContact } from "./contact";
+
+describe("buildLineFriendContact", () => {
+  it("有効な line.me の友だち追加URLをそのまま採用する", () => {
+    const result = buildLineFriendContact({
+      url: "https://line.me/R/ti/p/@volunty",
+      id: "@volunty",
+    });
+
+    expect(result.addUrl).toBe("https://line.me/R/ti/p/@volunty");
+    expect(result.displayId).toBe("@volunty");
+  });
+
+  it("有効な lin.ee の短縮URLを採用する", () => {
+    const result = buildLineFriendContact({
+      url: "https://lin.ee/abcd123",
+      id: null,
+    });
+
+    expect(result.addUrl).toBe("https://lin.ee/abcd123");
+    expect(result.displayId).toBeNull();
+  });
+
+  it("URLが無く @id があるとき line.me URL を生成する", () => {
+    const result = buildLineFriendContact({ url: null, id: "@volunty" });
+
+    expect(result.addUrl).toBe("https://line.me/R/ti/p/@volunty");
+    expect(result.displayId).toBe("@volunty");
+  });
+
+  it("先頭に @ が無い id にも @ を補ってURLを生成する", () => {
+    const result = buildLineFriendContact({ url: "", id: "volunty" });
+
+    expect(result.addUrl).toBe("https://line.me/R/ti/p/@volunty");
+    expect(result.displayId).toBe("volunty");
+  });
+
+  it("http や他ドメインのURLは却下し、idからのフォールバックも無ければ null", () => {
+    const httpResult = buildLineFriendContact({
+      url: "http://line.me/R/ti/p/@x",
+      id: null,
+    });
+    expect(httpResult.addUrl).toBeNull();
+
+    const otherDomain = buildLineFriendContact({
+      url: "https://evil.example.com/@x",
+      id: null,
+    });
+    expect(otherDomain.addUrl).toBeNull();
+  });
+
+  it("不正な文字を含む id は URL 生成に使わない", () => {
+    const result = buildLineFriendContact({ url: null, id: "  invalid id!! " });
+
+    expect(result.addUrl).toBeNull();
+    expect(result.displayId).toBe("invalid id!!");
+  });
+
+  it("URL も id も無効なら addUrl / displayId とも null", () => {
+    const result = buildLineFriendContact({ url: null, id: null });
+
+    expect(result.addUrl).toBeNull();
+    expect(result.displayId).toBeNull();
+  });
+});

--- a/app/src/lib/line/contact.ts
+++ b/app/src/lib/line/contact.ts
@@ -1,0 +1,49 @@
+export interface LineContactInput {
+  url: string | null;
+  id: string | null;
+}
+
+export interface LineFriendContact {
+  addUrl: string | null;
+  displayId: string | null;
+}
+
+const ALLOWED_HOSTS = new Set(["line.me", "lin.ee"]);
+const BASIC_ID_PATTERN = /^@?[A-Za-z0-9._-]+$/;
+
+function normalizeFriendAddUrl(url: string | null): string | null {
+  if (!url) return null;
+
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:") return null;
+    if (!ALLOWED_HOSTS.has(parsed.hostname)) return null;
+
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+function buildUrlFromId(id: string | null): string | null {
+  if (!id) return null;
+
+  const trimmed = id.trim();
+  if (!trimmed || !BASIC_ID_PATTERN.test(trimmed)) return null;
+
+  const withAt = trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+  return `https://line.me/R/ti/p/${withAt}`;
+}
+
+export function buildLineFriendContact(
+  input: LineContactInput,
+): LineFriendContact {
+  const addUrl = normalizeFriendAddUrl(input.url) ?? buildUrlFromId(input.id);
+  const trimmedId = input.id?.trim();
+  const displayId = trimmedId ? trimmedId : null;
+
+  return { addUrl, displayId };
+}

--- a/app/src/lib/mypage/actions.test.ts
+++ b/app/src/lib/mypage/actions.test.ts
@@ -425,6 +425,72 @@ describe("fetchMyApplicationDetail", () => {
     expect(result.application?.opportunity.organization_line_id).toBe("@line_a");
   });
 
+  it("マッチング成立時は organization_line_url を返す", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    mockFindFirstMatchingCandidate.mockResolvedValue({
+      id: "app-4",
+      status: "accepted",
+      message: null,
+      appliedAt: new Date("2026-02-01T00:00:00.000Z"),
+      createdAt: new Date("2026-02-01T00:00:00.000Z"),
+      statusChangedAt: new Date("2026-02-05T00:00:00.000Z"),
+      opportunity: {
+        id: "opp-4",
+        title: "子ども支援",
+        description: null,
+        location: null,
+        startDate: null,
+        endDate: null,
+        category: null,
+        participationMode: null,
+        organization: {
+          organizationName: "支援団体A",
+          contactLineId: "@line_a",
+          contactLineUrl: "https://line.me/R/ti/p/@line_a",
+        },
+      },
+    });
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-4");
+
+    expect(result.application?.opportunity.organization_line_url).toBe(
+      "https://line.me/R/ti/p/@line_a"
+    );
+  });
+
+  it("審査中は organization_line_url を秘匿する", async () => {
+    mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
+    mockFindFirstMatchingCandidate.mockResolvedValue({
+      id: "app-5",
+      status: "applied",
+      message: null,
+      appliedAt: new Date("2026-02-01T00:00:00.000Z"),
+      createdAt: new Date("2026-02-01T00:00:00.000Z"),
+      statusChangedAt: new Date("2026-02-01T00:00:00.000Z"),
+      opportunity: {
+        id: "opp-5",
+        title: "子ども支援",
+        description: null,
+        location: null,
+        startDate: null,
+        endDate: null,
+        category: null,
+        participationMode: null,
+        organization: {
+          organizationName: "支援団体A",
+          contactLineId: "@line_a",
+          contactLineUrl: "https://line.me/R/ti/p/@line_a",
+        },
+      },
+    });
+
+    const { fetchMyApplicationDetail } = await import("./actions");
+    const result = await fetchMyApplicationDetail("app-5");
+
+    expect(result.application?.opportunity.organization_line_url).toBeNull();
+  });
+
   it("completed ステータスの場合、証明書申請可能フラグと完了日を返す", async () => {
     mockGetUser.mockReturnValue({ data: { user: { id: "user-1" } }, error: null });
     const completedAt = new Date("2026-03-10T12:00:00.000Z");

--- a/app/src/lib/mypage/actions.ts
+++ b/app/src/lib/mypage/actions.ts
@@ -329,6 +329,7 @@ export async function fetchMyApplicationDetail(
               select: {
                 organizationName: true,
                 contactLineId: true,
+                contactLineUrl: true,
               },
             },
           },
@@ -386,6 +387,9 @@ export async function fetchMyApplicationDetail(
           organization_name: candidate.opportunity.organization.organizationName,
           organization_line_id: showContact
             ? (candidate.opportunity.organization.contactLineId ?? null)
+            : null,
+          organization_line_url: showContact
+            ? (candidate.opportunity.organization.contactLineUrl ?? null)
             : null,
         },
       },

--- a/app/src/lib/mypage/types.ts
+++ b/app/src/lib/mypage/types.ts
@@ -72,6 +72,8 @@ export interface ApplicationDetailOpportunity {
   organization_name: string;
   /** マッチング成立（approved / completed）時のみ含まれる */
   organization_line_id: string | null;
+  /** マッチング成立（approved / completed）時のみ含まれる友だち追加URL */
+  organization_line_url: string | null;
 }
 
 /** 応募詳細情報（fetchMyApplicationDetail の戻り値本体） */


### PR DESCRIPTION
## Summary

- LINE連絡先を友だち追加URLへ正規化する純粋関数を追加
- マッチング成立後の応募詳細・アプローチ詳細で友だち追加ボタン、QRコード、LINE IDフォールバックを表示
- QRコード生成用に qrcode / @types/qrcode を追加し、表示・ゲート条件のテストを追加

## Verification

- npm run lint: 成功（既存の update-opportunity.test.ts に warning 1件）
- npx tsc --noEmit: 成功
- npm test: 成功（47 files / 306 tests）
- npm run build: 成功（/diagnosis/result の dynamic server usage ログあり、exit 0）

## Notes

- 開示ゲートは既存どおり応募詳細は approved / completed、アプローチ詳細は accepted のまま変更していません。
- 既存の未コミット差分 .codex/config.toml はPR対象に含めていません。