### PR TITLE
feat: アカウント凍結機能を実装する

### DIFF
--- a/app/prisma/migrations/20260621000000_add_user_suspension_audit/migration.sql
+++ b/app/prisma/migrations/20260621000000_add_user_suspension_audit/migration.sql
@@ -1,0 +1,4 @@
+-- アカウント凍結の監査カラムを m_user に追加
+ALTER TABLE "m_user" ADD COLUMN "suspended_at" TIMESTAMP(3);
+ALTER TABLE "m_user" ADD COLUMN "suspend_reason" TEXT;
+ALTER TABLE "m_user" ADD COLUMN "suspended_by" UUID;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -96,15 +96,18 @@ enum CertificateStatus {
 /// ユーザー — Supabase Auth と連携
 /// id は auth.users.id と一致させる（トリガーで自動作成）
 model User {
-  id          String    @id @db.Uuid
-  role        UserRole  @default(participant)
-  email       String?   @db.VarChar(255)
-  name        String?   @db.VarChar(100)
-  avatarUrl   String?   @map("avatar_url")
-  isActive    Boolean   @default(true) @map("is_active")
-  lastLoginAt DateTime? @map("last_login_at")
-  createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @updatedAt @map("updated_at")
+  id            String    @id @db.Uuid
+  role          UserRole  @default(participant)
+  email         String?   @db.VarChar(255)
+  name          String?   @db.VarChar(100)
+  avatarUrl     String?   @map("avatar_url")
+  isActive      Boolean   @default(true) @map("is_active")
+  suspendedAt   DateTime? @map("suspended_at")
+  suspendReason String?   @map("suspend_reason") @db.Text
+  suspendedBy   String?   @map("suspended_by") @db.Uuid
+  lastLoginAt   DateTime? @map("last_login_at")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
 
   // リレーション
   participantProfile  ParticipantProfile?

--- a/app/src/app/admin/users/AdminUserList.test.tsx
+++ b/app/src/app/admin/users/AdminUserList.test.tsx
@@ -1,8 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { AdminUserList } from "./AdminUserList";
 import type { AdminUserListItem } from "@/lib/admin/actions";
+
+vi.mock("@/lib/admin/actions", () => ({
+  suspendUser: vi.fn(),
+  reactivateUser: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
 
 const users: AdminUserListItem[] = [
   {
@@ -12,6 +21,8 @@ const users: AdminUserListItem[] = [
     email: "participant@example.com",
     avatarUrl: null,
     isActive: true,
+    suspendedAt: null,
+    suspendReason: null,
     region: "東京都",
     organizationVerified: null,
     lastLoginAt: "2026-06-19T10:00:00.000Z",
@@ -24,6 +35,8 @@ const users: AdminUserListItem[] = [
     email: "org@example.com",
     avatarUrl: null,
     isActive: false,
+    suspendedAt: "2026-06-19T12:00:00.000Z",
+    suspendReason: "規約違反のため",
     region: null,
     organizationVerified: true,
     lastLoginAt: null,
@@ -36,6 +49,8 @@ const users: AdminUserListItem[] = [
     email: "admin@example.com",
     avatarUrl: null,
     isActive: true,
+    suspendedAt: null,
+    suspendReason: null,
     region: null,
     organizationVerified: null,
     lastLoginAt: null,
@@ -66,12 +81,17 @@ describe("AdminUserList", () => {
     expect(screen.queryByText("admin@example.com")).toBeNull();
   });
 
-  it("停止中ユーザーは状態バッジのみ表示し、凍結操作は表示しない", () => {
+  it("参加者と団体には凍結/解除操作を表示し、管理者には表示しない", () => {
     render(<AdminUserList users={users} />);
 
     expect(screen.getByText("停止中")).toBeDefined();
-    expect(screen.queryByRole("button", { name: "停止する" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "解除する" })).toBeNull();
+    expect(screen.getByRole("button", { name: "凍結する" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "凍結を解除" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /管理者\s+1/ }));
+
+    expect(screen.getByRole("heading", { name: "管理者" })).toBeDefined();
     expect(screen.queryByRole("button", { name: "凍結する" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "凍結を解除" })).toBeNull();
   });
 });

--- a/app/src/app/admin/users/AdminUserList.tsx
+++ b/app/src/app/admin/users/AdminUserList.tsx
@@ -17,6 +17,7 @@ import {
 import { Card, CardContent } from "@/app/components/ui/Card";
 import { Input } from "@/app/components/ui/Input";
 import type { AdminUserListItem } from "@/lib/admin/actions";
+import { UserSuspensionControl } from "./UserSuspensionControl";
 
 interface Props {
   users: AdminUserListItem[];
@@ -216,6 +217,8 @@ export function AdminUserList({ users }: Props) {
                       <span>登録日: {formatDate(user.createdAt)}</span>
                     </div>
                   </div>
+
+                  <UserSuspensionControl user={user} />
                 </CardContent>
               </Card>
             );

--- a/app/src/app/admin/users/UserSuspensionControl.test.tsx
+++ b/app/src/app/admin/users/UserSuspensionControl.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UserSuspensionControl } from "./UserSuspensionControl";
+
+const mocks = vi.hoisted(() => ({
+  suspendUser: vi.fn(),
+  reactivateUser: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/actions", () => ({
+  suspendUser: mocks.suspendUser,
+  reactivateUser: mocks.reactivateUser,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}));
+
+const activeParticipant = {
+  id: "u-1",
+  role: "participant" as const,
+  displayName: "山田太郎",
+  email: "yamada@example.com",
+  avatarUrl: null,
+  isActive: true,
+  suspendedAt: null,
+  suspendReason: null,
+  region: "東京都",
+  organizationVerified: null,
+  lastLoginAt: null,
+  createdAt: "2026-06-01T00:00:00.000Z",
+};
+
+describe("UserSuspensionControl", () => {
+  beforeEach(() => {
+    mocks.suspendUser.mockReset();
+    mocks.reactivateUser.mockReset();
+    mocks.refresh.mockReset();
+  });
+
+  it("管理者ロールには操作を表示しない", () => {
+    const { container } = render(
+      <UserSuspensionControl user={{ ...activeParticipant, role: "admin" }} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("凍結ボタン押下で理由入力を要求し、Actionを呼ぶ", async () => {
+    mocks.suspendUser.mockResolvedValue({ success: true });
+    render(<UserSuspensionControl user={activeParticipant} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "凍結する" }));
+    fireEvent.change(screen.getByPlaceholderText("凍結理由を入力してください"), {
+      target: { value: "規約違反" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "凍結を確定" }));
+
+    await waitFor(() =>
+      expect(mocks.suspendUser).toHaveBeenCalledWith("u-1", "規約違反")
+    );
+    expect(mocks.refresh).toHaveBeenCalled();
+  });
+
+  it("凍結中ユーザーには解除ボタンを表示する", async () => {
+    mocks.reactivateUser.mockResolvedValue({ success: true });
+    render(
+      <UserSuspensionControl
+        user={{
+          ...activeParticipant,
+          isActive: false,
+          suspendReason: "規約違反",
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "凍結を解除" }));
+
+    await waitFor(() =>
+      expect(mocks.reactivateUser).toHaveBeenCalledWith("u-1")
+    );
+  });
+});

--- a/app/src/app/admin/users/UserSuspensionControl.tsx
+++ b/app/src/app/admin/users/UserSuspensionControl.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Ban, RotateCcw } from "lucide-react";
+import { Button } from "@/app/components/ui/Button";
+import type { AdminUserListItem } from "@/lib/admin/actions";
+import { reactivateUser, suspendUser } from "@/lib/admin/actions";
+
+interface Props {
+  user: AdminUserListItem;
+}
+
+export function UserSuspensionControl({ user }: Props) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  if (user.role === "admin") {
+    return null;
+  }
+
+  const normalizedReason = reason.trim();
+
+  const handleSuspend = () => {
+    if (!normalizedReason) {
+      setFeedback("凍結理由を入力してください");
+      return;
+    }
+
+    startTransition(async () => {
+      setFeedback(null);
+      const result = await suspendUser(user.id, normalizedReason);
+      if (result.success) {
+        setIsOpen(false);
+        setReason("");
+        router.refresh();
+        return;
+      }
+      setFeedback(result.error ?? "凍結に失敗しました");
+    });
+  };
+
+  const handleReactivate = () => {
+    startTransition(async () => {
+      setFeedback(null);
+      const result = await reactivateUser(user.id);
+      if (result.success) {
+        router.refresh();
+        return;
+      }
+      setFeedback(result.error ?? "凍結解除に失敗しました");
+    });
+  };
+
+  if (!user.isActive) {
+    return (
+      <div className="flex flex-col gap-2 border-t border-card-border pt-3">
+        {user.suspendReason && (
+          <p className="text-xs text-text-body">
+            凍結理由:{" "}
+            <span className="text-text-dark">{user.suspendReason}</span>
+          </p>
+        )}
+        {feedback && <p className="text-sm text-red-700">{feedback}</p>}
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            icon={RotateCcw}
+            onClick={handleReactivate}
+            disabled={isPending}
+          >
+            {isPending ? "処理中..." : "凍結を解除"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-card-border pt-3">
+      {isOpen && (
+        <textarea
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          rows={2}
+          placeholder="凍結理由を入力してください"
+          className="w-full rounded-lg border border-input-border bg-white px-3 py-2 text-sm text-text-dark placeholder:text-text-body focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+      )}
+      {feedback && <p className="text-sm text-red-700">{feedback}</p>}
+      <div className="flex justify-end gap-2">
+        {isOpen ? (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setIsOpen(false);
+                setReason("");
+                setFeedback(null);
+              }}
+              disabled={isPending}
+            >
+              キャンセル
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              icon={Ban}
+              onClick={handleSuspend}
+              disabled={isPending || !normalizedReason}
+              className="border-red-200 text-red-700 hover:bg-red-50"
+            >
+              {isPending ? "処理中..." : "凍結を確定"}
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            icon={Ban}
+            onClick={() => setIsOpen(true)}
+            className="border-red-200 text-red-700 hover:bg-red-50"
+          >
+            凍結する
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/app/auth/signout/route.ts
+++ b/app/src/app/auth/signout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/** 凍結ユーザーなどを強制サインアウトしてログインへ戻す */
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const reason = requestUrl.searchParams.get("reason");
+  const origin = requestUrl.origin.replace("//0.0.0.0:", "//localhost:");
+
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+
+  const loginUrl = new URL("/login", origin);
+  if (reason === "suspended") {
+    loginUrl.searchParams.set("error", "suspended");
+  }
+
+  return NextResponse.redirect(loginUrl.toString());
+}

--- a/app/src/app/components/ui/ToastProvider.tsx
+++ b/app/src/app/components/ui/ToastProvider.tsx
@@ -68,6 +68,15 @@ function collectUrlToasts(searchParams: URLSearchParams): UrlToastResult {
     consumedParams.push("error");
   }
 
+  if (searchParams.get("error") === "suspended") {
+    toasts.push({
+      type: "error",
+      title: "アカウントが凍結されています",
+      description: "ご利用できません。お問い合わせください。",
+    });
+    consumedParams.push("error");
+  }
+
   if (searchParams.get("accountDeleted") === "1") {
     toasts.push({
       type: "success",

--- a/app/src/lib/admin/actions.test.ts
+++ b/app/src/lib/admin/actions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetUser = vi.fn();
 const mockFindUser = vi.fn();
 const mockFindUsers = vi.fn();
+const mockUpdateUser = vi.fn();
 const mockCountUsers = vi.fn();
 const mockCountMatchingCandidates = vi.fn();
 const mockCountOrganizations = vi.fn();
@@ -28,6 +29,7 @@ vi.mock("@/lib/prisma", () => ({
     user: {
       findUnique: (...args: unknown[]) => mockFindUser(...args),
       findMany: (...args: unknown[]) => mockFindUsers(...args),
+      update: (...args: unknown[]) => mockUpdateUser(...args),
       count: (...args: unknown[]) => mockCountUsers(...args),
     },
     matchingCandidate: {
@@ -104,6 +106,8 @@ describe("admin/actions", () => {
         name: "  ",
         avatarUrl: null,
         isActive: true,
+        suspendedAt: null,
+        suspendReason: null,
         lastLoginAt: new Date("2026-06-19T10:00:00.000Z"),
         createdAt: new Date("2026-06-18T10:00:00.000Z"),
         participantProfile: {
@@ -119,6 +123,8 @@ describe("admin/actions", () => {
         name: null,
         avatarUrl: "https://example.com/avatar.png",
         isActive: false,
+        suspendedAt: new Date("2026-06-19T12:00:00.000Z"),
+        suspendReason: "規約違反のため",
         lastLoginAt: null,
         createdAt: new Date("2026-06-17T10:00:00.000Z"),
         participantProfile: null,
@@ -134,6 +140,8 @@ describe("admin/actions", () => {
         name: "管理者",
         avatarUrl: null,
         isActive: true,
+        suspendedAt: null,
+        suspendReason: null,
         lastLoginAt: null,
         createdAt: new Date("2026-06-16T10:00:00.000Z"),
         participantProfile: null,
@@ -152,6 +160,8 @@ describe("admin/actions", () => {
         name: true,
         avatarUrl: true,
         isActive: true,
+        suspendedAt: true,
+        suspendReason: true,
         lastLoginAt: true,
         createdAt: true,
         participantProfile: {
@@ -170,6 +180,8 @@ describe("admin/actions", () => {
         email: "participant@example.com",
         avatarUrl: null,
         isActive: true,
+        suspendedAt: null,
+        suspendReason: null,
         region: "東京都",
         organizationVerified: null,
         lastLoginAt: "2026-06-19T10:00:00.000Z",
@@ -182,6 +194,8 @@ describe("admin/actions", () => {
         email: "org@example.com",
         avatarUrl: "https://example.com/avatar.png",
         isActive: false,
+        suspendedAt: "2026-06-19T12:00:00.000Z",
+        suspendReason: "規約違反のため",
         region: null,
         organizationVerified: true,
         lastLoginAt: null,
@@ -194,6 +208,8 @@ describe("admin/actions", () => {
         email: null,
         avatarUrl: null,
         isActive: true,
+        suspendedAt: null,
+        suspendReason: null,
         region: null,
         organizationVerified: null,
         lastLoginAt: null,
@@ -278,6 +294,8 @@ describe("admin/actions", () => {
         name: " ",
         avatarUrl: null,
         isActive: true,
+        suspendedAt: null,
+        suspendReason: null,
         lastLoginAt: null,
         createdAt: new Date("2026-06-18T10:00:00.000Z"),
         participantProfile: {
@@ -475,6 +493,92 @@ describe("admin/actions", () => {
         reviewComment: "提出情報を補足してください",
         reviewedBy: "admin-1",
       }),
+    });
+  });
+
+  describe("suspendUser", () => {
+    it("管理者が参加者を凍結できる", async () => {
+      mockFindUser
+        .mockResolvedValueOnce({ role: "admin" })
+        .mockResolvedValueOnce({ id: "target-1", role: "participant" });
+      mockUpdateUser.mockResolvedValue({});
+
+      const { suspendUser } = await import("./actions");
+      const result = await suspendUser("target-1", "規約違反のため");
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        where: { id: "target-1" },
+        data: expect.objectContaining({
+          isActive: false,
+          suspendReason: "規約違反のため",
+          suspendedBy: "admin-1",
+        }),
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/admin/users");
+    });
+
+    it("理由が空なら失敗する", async () => {
+      mockFindUser.mockResolvedValueOnce({ role: "admin" });
+
+      const { suspendUser } = await import("./actions");
+      const result = await suspendUser("target-1", "   ");
+
+      expect(result).toEqual({
+        success: false,
+        error: "凍結理由を入力してください",
+      });
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("管理者ロールのユーザーは凍結できない", async () => {
+      mockFindUser
+        .mockResolvedValueOnce({ role: "admin" })
+        .mockResolvedValueOnce({ id: "target-admin", role: "admin" });
+
+      const { suspendUser } = await import("./actions");
+      const result = await suspendUser("target-admin", "理由");
+
+      expect(result).toEqual({
+        success: false,
+        error: "管理者は凍結できません",
+      });
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("自分自身は凍結できない", async () => {
+      mockFindUser.mockResolvedValueOnce({ role: "admin" });
+
+      const { suspendUser } = await import("./actions");
+      const result = await suspendUser("admin-1", "理由");
+
+      expect(result).toEqual({
+        success: false,
+        error: "自分自身は凍結できません",
+      });
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reactivateUser", () => {
+    it("凍結を解除し監査カラムをクリアする", async () => {
+      mockFindUser.mockResolvedValueOnce({ role: "admin" });
+      mockUpdateUser.mockResolvedValue({});
+
+      const { reactivateUser } = await import("./actions");
+      const result = await reactivateUser("target-1");
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        where: { id: "target-1" },
+        data: {
+          isActive: true,
+          suspendedAt: null,
+          suspendReason: null,
+          suspendedBy: null,
+        },
+      });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/admin/users");
     });
   });
 });

--- a/app/src/lib/admin/actions.ts
+++ b/app/src/lib/admin/actions.ts
@@ -56,6 +56,8 @@ export interface AdminUserListItem {
   email: string | null;
   avatarUrl: string | null;
   isActive: boolean;
+  suspendedAt: string | null;
+  suspendReason: string | null;
   region: string | null;
   organizationVerified: boolean | null;
   lastLoginAt: string | null;
@@ -88,6 +90,8 @@ export async function fetchUsers(): Promise<AdminUserListItem[]> {
       name: true,
       avatarUrl: true,
       isActive: true,
+      suspendedAt: true,
+      suspendReason: true,
       lastLoginAt: true,
       createdAt: true,
       participantProfile: {
@@ -110,6 +114,8 @@ export async function fetchUsers(): Promise<AdminUserListItem[]> {
     email: user.email,
     avatarUrl: user.avatarUrl,
     isActive: user.isActive,
+    suspendedAt: user.suspendedAt?.toISOString() ?? null,
+    suspendReason: user.suspendReason,
     region:
       user.role === "participant"
         ? user.participantProfile?.region ?? null
@@ -354,6 +360,87 @@ export async function rejectOrganization(
     return {
       success: false,
       error: err instanceof Error ? err.message : "否認に失敗しました",
+    };
+  }
+}
+
+/** ユーザーアカウントを凍結する（管理者のみ） */
+export async function suspendUser(
+  userId: string,
+  reason: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const adminUser = await requireAdmin();
+
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      return { success: false, error: "凍結理由を入力してください" };
+    }
+
+    if (userId === adminUser.id) {
+      return { success: false, error: "自分自身は凍結できません" };
+    }
+
+    const target = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true },
+    });
+
+    if (!target) {
+      return { success: false, error: "対象ユーザーが見つかりません" };
+    }
+
+    if (target.role === "admin") {
+      return { success: false, error: "管理者は凍結できません" };
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        isActive: false,
+        suspendedAt: new Date(),
+        suspendReason: normalizedReason,
+        suspendedBy: adminUser.id,
+      },
+    });
+
+    revalidatePath("/admin/users");
+
+    return { success: true };
+  } catch (err) {
+    console.error("[suspendUser]", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "凍結に失敗しました",
+    };
+  }
+}
+
+/** ユーザーアカウントの凍結を解除する（管理者のみ） */
+export async function reactivateUser(
+  userId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await requireAdmin();
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        isActive: true,
+        suspendedAt: null,
+        suspendReason: null,
+        suspendedBy: null,
+      },
+    });
+
+    revalidatePath("/admin/users");
+
+    return { success: true };
+  } catch (err) {
+    console.error("[reactivateUser]", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "凍結解除に失敗しました",
     };
   }
 }

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -4,10 +4,28 @@ import { proxy } from "./proxy";
 
 const mocks = vi.hoisted(() => ({
   updateSession: vi.fn(),
+  createServerClient: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  maybeSingle: vi.fn(),
+  getSupabaseServerUrl: vi.fn(),
+  getSupabaseAnonKey: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/middleware", () => ({
   updateSession: mocks.updateSession,
+}));
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: (...args: unknown[]) =>
+    mocks.createServerClient(...args),
+}));
+
+vi.mock("@/lib/supabase/env", () => ({
+  getSupabaseServerUrl: () => mocks.getSupabaseServerUrl(),
+  getSupabaseAnonKey: () => mocks.getSupabaseAnonKey(),
+  SUPABASE_AUTH_COOKIE_NAME: "sb-test-auth-token",
 }));
 
 function createRequest(pathname: string): NextRequest {
@@ -21,9 +39,36 @@ function mockGuestSession(request: NextRequest) {
   });
 }
 
+function mockAuthenticatedSession(request: NextRequest, userId: string) {
+  mocks.updateSession.mockResolvedValue({
+    response: NextResponse.next({ request }),
+    user: {
+      id: userId,
+      user_metadata: {
+        role: "participant",
+        onboarding_completed: true,
+      },
+    },
+  });
+}
+
 describe("proxy", () => {
   beforeEach(() => {
     mocks.updateSession.mockReset();
+    mocks.createServerClient.mockReset();
+    mocks.from.mockReset();
+    mocks.select.mockReset();
+    mocks.eq.mockReset();
+    mocks.maybeSingle.mockReset();
+    mocks.getSupabaseServerUrl.mockReset();
+    mocks.getSupabaseAnonKey.mockReset();
+    mocks.getSupabaseServerUrl.mockReturnValue("https://supabase.example.com");
+    mocks.getSupabaseAnonKey.mockReturnValue("anon-key");
+    mocks.maybeSingle.mockResolvedValue({ data: { is_active: true } });
+    mocks.eq.mockReturnValue({ maybeSingle: mocks.maybeSingle });
+    mocks.select.mockReturnValue({ eq: mocks.eq });
+    mocks.from.mockReturnValue({ select: mocks.select });
+    mocks.createServerClient.mockReturnValue({ from: mocks.from });
   });
 
   it("未認証の未知URLはログインへ送らず404判定へ通す", async () => {
@@ -49,5 +94,35 @@ describe("proxy", () => {
     expect(response.status).toBe(307);
     expect(location.pathname).toBe("/login");
     expect(location.searchParams.get("next")).toBe("/dashboard");
+  });
+
+  it("有効な認証済みユーザーは保護ルートを通過する", async () => {
+    const request = createRequest("/mypage");
+    mockAuthenticatedSession(request, "active-1");
+    mocks.maybeSingle.mockResolvedValueOnce({ data: { is_active: true } });
+
+    const response = await proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mocks.from).toHaveBeenCalledWith("m_user");
+    expect(mocks.select).toHaveBeenCalledWith("is_active");
+    expect(mocks.eq).toHaveBeenCalledWith("id", "active-1");
+  });
+
+  it("凍結ユーザーは保護ルートで強制サインアウトされる", async () => {
+    const request = createRequest("/mypage");
+    mockAuthenticatedSession(request, "suspended-1");
+    mocks.maybeSingle.mockResolvedValueOnce({ data: { is_active: false } });
+
+    const response = await proxy(request);
+    const location = new URL(
+      response.headers.get("location") ?? "",
+      request.url
+    );
+
+    expect(response.status).toBe(307);
+    expect(location.pathname).toBe("/auth/signout");
+    expect(location.searchParams.get("reason")).toBe("suspended");
   });
 });

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -104,6 +104,43 @@ export async function proxy(request: NextRequest) {
     return redirectWithCookies(url, response);
   }
 
+  // --- 凍結チェック: is_active=false なら強制サインアウト ---
+  {
+    const supabaseUrl = getSupabaseServerUrl();
+    const supabaseAnonKey = getSupabaseAnonKey();
+    if (supabaseUrl && supabaseAnonKey) {
+      try {
+        const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+          cookieOptions: {
+            name: SUPABASE_AUTH_COOKIE_NAME,
+          },
+          cookies: {
+            getAll: () => request.cookies.getAll(),
+            setAll: (cookiesToSet) => {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                response.cookies.set(name, value, options)
+              );
+            },
+          },
+        });
+        const { data: account } = await supabase
+          .from("m_user")
+          .select("is_active")
+          .eq("id", user.id)
+          .maybeSingle();
+        if (account && account.is_active === false) {
+          const url = request.nextUrl.clone();
+          url.pathname = "/auth/signout";
+          url.search = "";
+          url.searchParams.set("reason", "suspended");
+          return redirectWithCookies(url, response);
+        }
+      } catch (err) {
+        console.error("[proxy] 凍結チェックに失敗:", err);
+      }
+    }
+  }
+
   // --- オンボーディングパス: 認証済みならスルー ---
   if (isOnboardingPath(pathname)) {
     return response;

--- a/supabase/migrations/20260621000000_add_user_suspension_audit.sql
+++ b/supabase/migrations/20260621000000_add_user_suspension_audit.sql
@@ -1,0 +1,4 @@
+-- アカウント凍結の監査カラムを m_user に追加
+ALTER TABLE "m_user" ADD COLUMN "suspended_at" TIMESTAMP(3);
+ALTER TABLE "m_user" ADD COLUMN "suspend_reason" TEXT;
+ALTER TABLE "m_user" ADD COLUMN "suspended_by" UUID;


### PR DESCRIPTION
## Summary

- `m_user.is_active` を凍結ゲートとして再利用し、凍結監査カラムを Prisma/Supabase 両マイグレーションに追加
- 管理者向け `suspendUser` / `reactivateUser` Server Action と管理ユーザー一覧の凍結/解除 UI を追加
- proxy で凍結ユーザーを `/auth/signout?reason=suspended` に送り、ログイン画面で凍結トーストを表示

## Issue #133 受け入れ条件

| 受け入れ条件 | 対応 |
| --- | --- |
| Prisma schema に凍結状態フィールド追加 + マイグレーション | `isActive` 再利用 + `suspendedAt` / `suspendReason` / `suspendedBy`、Prisma/Supabase 両 SQL 追加 |
| 凍結/解除の Server Action（admin ロール認可） | `suspendUser` / `reactivateUser`、`requireAdmin()`、自己凍結・管理者凍結の防止 |
| 凍結済みユーザーのログイン/操作を制限 | `src/proxy.ts` の `is_active` チェック + `/auth/signout` |
| ユーザー一覧画面 (S-49) から凍結操作 | `UserSuspensionControl` を `AdminUserList` に組み込み |
| テストを追加 | admin actions / proxy / UI テスト追加 |

## Verification

- `cd app && npm run db:generate` 成功
- `cd app && npm test` 成功（49 files / 323 tests）
- `cd app && npm run lint` 成功（既存の `src/lib/dashboard/update-opportunity.test.ts` 未使用 `_args` warning 1 件）
- `cd app && npm run build` 成功（既存の `/diagnosis/result` dynamic server usage ログあり、終了コード 0）

## Notes

- ローカル DB への `make db-migrate` は未実行です。
- Closes #133
