### PR TITLE
Google認証でアカウント選択を要求する

### DIFF
--- a/app/src/app/(auth)/login/page.test.tsx
+++ b/app/src/app/(auth)/login/page.test.tsx
@@ -46,6 +46,9 @@ describe("LoginPage", () => {
         provider: "google",
         options: {
           redirectTo: "http://localhost:3000/auth/callback?next=%2Fmypage",
+          queryParams: {
+            prompt: "select_account",
+          },
         },
       });
     });

--- a/app/src/app/(auth)/login/page.tsx
+++ b/app/src/app/(auth)/login/page.tsx
@@ -34,6 +34,9 @@ export default function LoginPage() {
       provider: "google",
       options: {
         redirectTo: buildAuthCallbackUrl(),
+        queryParams: {
+          prompt: "select_account",
+        },
       },
     });
   };

--- a/app/src/app/(auth)/signup/page.test.tsx
+++ b/app/src/app/(auth)/signup/page.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import SignupPage from "./page";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
+  signInWithOAuth: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -14,12 +15,18 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
     auth: {
-      signInWithOAuth: vi.fn(),
+      signInWithOAuth: mocks.signInWithOAuth,
     },
   }),
 }));
 
 describe("SignupPage", () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.signInWithOAuth.mockClear();
+    window.history.replaceState(null, "", "http://localhost:3000/signup");
+  });
+
   it("メール登録UIを表示せずGoogle登録だけ表示する", () => {
     render(<SignupPage />);
 
@@ -27,5 +34,23 @@ describe("SignupPage", () => {
     expect(screen.queryByLabelText("メールアドレス")).toBeNull();
     expect(screen.queryByRole("button", { name: "次へ (詳細情報の入力)" })).toBeNull();
     expect(screen.queryByText("または")).toBeNull();
+  });
+
+  it("Google登録時にアカウント選択を要求する", async () => {
+    render(<SignupPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Googleで登録" }));
+
+    await waitFor(() => {
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: "google",
+        options: {
+          redirectTo: "http://localhost:3000/auth/callback",
+          queryParams: {
+            prompt: "select_account",
+          },
+        },
+      });
+    });
   });
 });

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -23,6 +23,9 @@ export default function SignupPage() {
       provider: "google",
       options: {
         redirectTo: `${origin}/auth/callback`,
+        queryParams: {
+          prompt: "select_account",
+        },
       },
     });
   };


### PR DESCRIPTION
## Summary

- Googleログイン/登録のOAuthリクエストに `prompt=select_account` を追加
- ログイン画面の既存OAuthテストにアカウント選択要求の期待値を追加
- 登録画面のOAuth呼び出しテストを追加

## Verification

- `cd app && npx vitest run 'src/app/(auth)/login/page.test.tsx' 'src/app/(auth)/signup/page.test.tsx'` 成功（4 tests passed）
- `cd app && npm run lint` 成功（exit 0）

## Notes

- lint は成功していますが、既存の `app/src/lib/dashboard/update-opportunity.test.ts` に `_args` 未使用 warning が 1 件あります。
- 未追跡の `docs/operations/preview-database.md` はこのPRに含めていません。