### PR TITLE
feat: デザインシステムを白背景ベースに刷新

### DIFF
--- a/.agent-shared/skills/volunty-architecture-design/SKILL.md
+++ b/.agent-shared/skills/volunty-architecture-design/SKILL.md
@@ -56,11 +56,21 @@ RESTORE    └┘（次の質問へ / BACK で戻る）
 `@theme inline` で Tailwind クラス化されている CSS 変数を使う。
 
 ```css
---background: #ffeee2;
+/* ベース（白系背景 + ウォームニュートラル） */
+--background: #faf9f7;
+--text-dark: #241c17;
+--text-body: #5d534c;
+
+/* ブランド */
 --primary: #fb5b01;
 --primary-dark: #c74700;
---text-dark: #6d2700;
---text-body: #8b4513;
+--primary-light: #fb8a3c;
+
+/* セカンダリー（オレンジの補色系ティールブルー）・セマンティック */
+--secondary: #0e7490;
+--success: #15803d;
+--warning: #b45309; /* 注意ボックスは --warning-bg / --warning-border と併用 */
+--error: #dc2626;
 ```
 
 ## 関連ファイル

--- a/app/src/app/components/lp/DiagnosisTypesCarousel.tsx
+++ b/app/src/app/components/lp/DiagnosisTypesCarousel.tsx
@@ -11,7 +11,7 @@ const TYPES: {
   gradient: string;
   accent: string;
 }[] = [
-  { name: "縁の下の力持ちタイプ", icon: Users,         iconBg: "bg-orange-100 text-orange-600", scores: { 外向性: 32, 協調性: 70, 誠実性: 90, 開放性: 52 }, activity: "資料整理・受付サポート",       match: 91, gradient: "from-orange-50 to-amber-50",   accent: "#fb5b01" },
+  { name: "縁の下の力持ちタイプ", icon: Users,         iconBg: "bg-primary/10 text-primary", scores: { 外向性: 32, 協調性: 70, 誠実性: 90, 開放性: 52 }, activity: "資料整理・受付サポート",       match: 91, gradient: "from-orange-50 to-amber-50",   accent: "#fb5b01" },
   { name: "リーダータイプ",       icon: Star,          iconBg: "bg-red-100 text-red-600",       scores: { 外向性: 88, 協調性: 66, 誠実性: 74, 開放性: 70 }, activity: "地域イベントの運営スタッフ", match: 93, gradient: "from-red-50 to-orange-50",     accent: "#ef4444" },
   { name: "アイデアマンタイプ",   icon: Lightbulb,     iconBg: "bg-purple-100 text-purple-600", scores: { 外向性: 78, 協調性: 86, 誠実性: 64, 開放性: 92 }, activity: "子ども向け工作ワークショップ", match: 94, gradient: "from-purple-50 to-violet-50", accent: "#8b5cf6" },
   { name: "実行力タイプ",         icon: Zap,           iconBg: "bg-green-100 text-green-600",   scores: { 外向性: 70, 協調性: 58, 誠実性: 82, 開放性: 60 }, activity: "河川敷の清掃・緑化活動",       match: 90, gradient: "from-green-50 to-emerald-50", accent: "#10b981" },

--- a/app/src/app/components/lp/DiagnosisTypesGrid.tsx
+++ b/app/src/app/components/lp/DiagnosisTypesGrid.tsx
@@ -21,7 +21,7 @@ const TYPE_DISPLAY: Record<string, { icon: typeof Users; color: string }> = {
   "charisma-entertainer": { icon: MessageCircle, color: "bg-yellow-100 text-yellow-600" },
   "strategist-planner": { icon: Zap, color: "bg-green-100 text-green-600" },
   "harmony-mediator": { icon: Handshake, color: "bg-blue-100 text-blue-600" },
-  "adventure-explorer": { icon: Compass, color: "bg-orange-100 text-orange-600" },
+  "adventure-explorer": { icon: Compass, color: "bg-primary/10 text-primary" },
   "conservative-guardian": { icon: Shield, color: "bg-teal-100 text-teal-600" },
   "sensitive-artist": { icon: Users, color: "bg-rose-100 text-rose-600" },
 };
@@ -44,7 +44,7 @@ export function DiagnosisTypesGrid() {
         {ACTIVITY_STYLE_TYPES.map((type) => {
           const display = TYPE_DISPLAY[type.id] ?? {
             icon: Users,
-            color: "bg-orange-100 text-orange-600",
+            color: "bg-primary/10 text-primary",
           };
           const Icon = display.icon;
           return (

--- a/app/src/app/components/lp/HowItWorksSection.tsx
+++ b/app/src/app/components/lp/HowItWorksSection.tsx
@@ -6,7 +6,7 @@ const STEPS = [
     icon: Brain,
     title: "性格傾向チェック",
     desc: "世界中で使われている性格研究をもとに、5つの性格特性の傾向を確認します。簡易診断（15問）と全50問から選べます。",
-    color: "bg-orange-100 text-orange-600",
+    color: "bg-primary/10 text-primary",
   },
   {
     num: "02",
@@ -28,7 +28,7 @@ export function HowItWorksSection() {
   return (
     <section id="shikumi" className="glass-card relative z-10 mt-20 overflow-hidden rounded-3xl p-8 ring-1 ring-white/60 sm:mt-28 sm:p-12">
       <div className="lp-blob -top-12 -right-12 size-72 bg-primary/20" aria-hidden />
-      <div className="lp-blob -bottom-16 -left-16 size-72 bg-[#fbb672]/30" aria-hidden />
+      <div className="lp-blob -bottom-16 -left-16 size-72 bg-primary-light/30" aria-hidden />
 
       <div className="mb-10 text-center">
         <p className="mb-3 text-sm font-medium text-primary">✦ Voluntyの仕組み ✦</p>

--- a/app/src/app/components/lp/HowToUseSection.tsx
+++ b/app/src/app/components/lp/HowToUseSection.tsx
@@ -7,7 +7,7 @@ const STEPS = [
     icon: ClipboardList,
     title: "診断・登録",
     desc: "性格傾向チェック（簡易15問・約2分/全50問・約5〜8分から選べます）で、あなたの特性の傾向を確認。登録は無料です。",
-    color: "bg-orange-100 text-orange-600",
+    color: "bg-primary/10 text-primary",
   },
   {
     num: "2",

--- a/app/src/app/components/lp/LPBottomCTA.tsx
+++ b/app/src/app/components/lp/LPBottomCTA.tsx
@@ -3,7 +3,7 @@ import { Zap, Brain } from "lucide-react";
 
 export function LPBottomCTA() {
   return (
-    <section className="relative z-10 mt-20 overflow-hidden rounded-3xl bg-linear-to-br from-[#fb8a3c] via-primary to-primary-dark p-8 text-center text-white shadow-xl sm:mt-28 sm:p-14">
+    <section className="relative z-10 mt-20 overflow-hidden rounded-3xl bg-linear-to-br from-primary-light via-primary to-primary-dark p-8 text-center text-white shadow-xl sm:mt-28 sm:p-14">
       <div className="pointer-events-none absolute -top-24 -right-24 size-72 rounded-full bg-white/15 blur-3xl" aria-hidden />
       <div className="pointer-events-none absolute -bottom-24 -left-16 size-80 rounded-full bg-white/10 blur-3xl" aria-hidden />
 

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -68,7 +68,7 @@ function reviewStatusDisplay(status: "pending" | "approved" | "rejected") {
       return {
         label: "審査中",
         icon: <CircleDashed className="size-4" />,
-        color: "border-amber-200 bg-amber-50 text-amber-800",
+        color: "border-warning-border bg-warning-bg text-warning",
         description: "審査完了まで一部機能は利用できません。",
       };
   }
@@ -201,7 +201,7 @@ export default async function DashboardPage() {
           </div>
         </div>
 
-        <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+        <div className="mb-6 rounded-xl border border-warning-border bg-warning-bg px-4 py-3 text-sm text-warning">
           団体プロフィールを更新すると、内容確認のため再審査になります。更新後は審査完了までダッシュボードを利用できません。
         </div>
 

--- a/app/src/app/dashboard/profile/edit/page.tsx
+++ b/app/src/app/dashboard/profile/edit/page.tsx
@@ -61,7 +61,7 @@ export default async function OrganizationProfileEditPage() {
     <div className="min-h-screen bg-background font-sans">
       <Header />
       <main className="mx-auto max-w-3xl px-6 py-8">
-        <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+        <div className="mb-6 rounded-xl border border-warning-border bg-warning-bg px-4 py-3 text-sm text-warning">
           承認済みプロフィールを修正すると、確認のため再審査になります。保存後は審査完了まで審査待ち画面へ移動します。
         </div>
         <OrganizationProfileForm

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -2,19 +2,39 @@
 
 :root {
   --font-noto-sans-jp: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;
-  --background: #ffeee2;
-  --foreground: #6d2700;
+
+  /* ベース: 白系背景 + ウォームニュートラルのテキスト */
+  --background: #faf9f7;
+  --foreground: #241c17;
+  --text-dark: #241c17;
+  --text-body: #5d534c;
+
+  /* ブランド: オレンジ系 */
   --primary: #fb5b01;
   --primary-dark: #c74700;
+  --primary-light: #fb8a3c;
+
+  /* セカンダリー: オレンジの補色系（ティールブルー） */
+  --secondary: #0e7490;
+  --secondary-dark: #155e75;
+
+  /* セマンティック */
+  --success: #15803d;
+  --warning: #b45309;
+  --warning-bg: #fffbeb;
+  --warning-border: #fde68a;
+  --error: #dc2626;
+
+  /* LINE ブランドカラー（ログインボタン用・変更不可） */
   --line-green: #06c755;
   --line-green-dark: #05a646;
-  --text-dark: #6d2700;
-  --text-body: #8b4513;
-  --card-border: rgba(203, 71, 0, 0.2);
-  --header-border: rgba(203, 71, 0, 0.1);
-  --tab-bg: #f5dcc8;
-  --input-border: rgba(251, 91, 1, 0.3);
-  --divider-border: #f5dcc8;
+
+  /* サーフェス・ボーダー */
+  --card-border: rgba(36, 28, 23, 0.1);
+  --header-border: rgba(36, 28, 23, 0.06);
+  --tab-bg: #f1ede9;
+  --input-border: rgba(36, 28, 23, 0.16);
+  --divider-border: #ece7e2;
 }
 
 @theme inline {
@@ -22,6 +42,14 @@
   --color-foreground: var(--foreground);
   --color-primary: var(--primary);
   --color-primary-dark: var(--primary-dark);
+  --color-primary-light: var(--primary-light);
+  --color-secondary: var(--secondary);
+  --color-secondary-dark: var(--secondary-dark);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-warning-bg: var(--warning-bg);
+  --color-warning-border: var(--warning-border);
+  --color-error: var(--error);
   --color-line-green: var(--line-green);
   --color-line-green-dark: var(--line-green-dark);
   --color-text-dark: var(--text-dark);

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -34,8 +34,8 @@ export default async function Home() {
         <main className="relative mx-auto w-full max-w-7xl overflow-x-hidden px-4 pt-8 pb-20 sm:px-6 lg:px-8">
           {/* 背景 blob 装飾 */}
           <div className="lp-blob top-[120px] -left-32 size-[420px] bg-primary/25" aria-hidden />
-          <div className="lp-blob top-[640px] -right-32 size-[520px] bg-[#fbb672]/40" aria-hidden />
-          <div className="lp-blob top-[1400px] left-1/3 size-[480px] bg-[#3b82f6]/15" aria-hidden />
+          <div className="lp-blob top-[640px] -right-32 size-[520px] bg-primary-light/40" aria-hidden />
+          <div className="lp-blob top-[1400px] left-1/3 size-[480px] bg-secondary/15" aria-hidden />
           <div className="lp-blob top-[2200px] -left-24 size-[500px] bg-primary/15" aria-hidden />
 
           {/* ヒーロー */}


### PR DESCRIPTION
## Summary

- 背景を白系（`#faf9f7`）に刷新し、primaryカラー `#fb5b01` は維持
- ウォームニュートラルのテキストカラー（`--text-dark` / `--text-body`）へ変更し、白背景でのコントラストを確保
- secondary（ティールブルー `#0e7490`）、success/warning/error のセマンティックカラートークンを新設
- LP・ダッシュボードでハードコードされていた `orange-100` / `amber-50` / `#fbb672` 等の色クラスをデザイントークン（`bg-primary/10`, `bg-warning-bg` など）へ置換
- `.agent-shared/skills/volunty-architecture-design/SKILL.md` のデザインカラー節を新パレットに合わせて更新

## Verification

- `npm run lint`: 成功
- `npm test`（57ファイル / 432件）: 全件成功
- `npm run build`: 成功
- ビルド後CSSに旧配色（`#ffeee2` 等）が残っていないことを確認
- 開発サーバーでLP・ログイン画面を実表示し、白背景+オレンジの新テーマが崩れなく描画されることを確認

## Notes

- 10タイプ診断カードの多色パレット（red/purple/teal等）は意図的なデザインとして維持し変更していません
- UT/E2Eは新規追加なし: CSS変数値・クラス名の変更のみで分岐ロジックやユーザーフロー・DOM構造の変更を伴わないため（既存テストは色クラスをassertしていないことを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)