### PR TITLE
細かな不具合修正

### DIFF
--- a/app/e2e/common-boundaries.spec.ts
+++ b/app/e2e/common-boundaries.spec.ts
@@ -175,7 +175,12 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
   await expect(
     participantPage.getByRole("heading", { name: "性格傾向チェックを始める" })
   ).toHaveCount(0);
-  await participantPage.getByRole("button", { name: "メニューを開く" }).click();
+  await expect(
+    participantPage.getByRole("link", { name: /おすすめ案件/ })
+  ).toBeVisible();
+  await expect(
+    participantPage.getByRole("link", { name: /性格傾向チェック/ })
+  ).toBeVisible();
   await participantPage.getByRole("link", { name: "マイページ" }).click();
   await expect(participantPage).toHaveURL(/\/mypage$/);
   await participantContext.close();
@@ -191,9 +196,6 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
       name: "性格傾向チェックを始める",
     })
   ).toHaveCount(0);
-  await participantDiagnosisPage
-    .getByRole("button", { name: "メニューを開く" })
-    .click();
   await participantDiagnosisPage.getByRole("link", { name: "マイページ" }).click();
   await expect(participantDiagnosisPage).toHaveURL(/\/mypage$/);
   await expect(
@@ -212,7 +214,12 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
   await expect(
     organizationPage.getByRole("heading", { name: "性格傾向チェックを始める" })
   ).toHaveCount(0);
-  await organizationPage.getByRole("button", { name: "メニューを開く" }).click();
+  await expect(
+    organizationPage.getByRole("link", { name: /新しい案件を作成/ })
+  ).toBeVisible();
+  await expect(
+    organizationPage.getByRole("link", { name: /おすすめ参加者/ })
+  ).toBeVisible();
   await organizationPage.getByRole("link", { name: "ダッシュボード" }).click();
   await expect(organizationPage).toHaveURL(/\/dashboard$/);
   await organizationContext.close();
@@ -226,7 +233,12 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
   await expect(
     adminPage.getByRole("heading", { name: "性格傾向チェックを始める" })
   ).toHaveCount(0);
-  await adminPage.goto("/admin");
+  await expect(
+    adminPage.getByRole("link", { name: /管理ダッシュボード/ })
+  ).toBeVisible();
+  await expect(
+    adminPage.getByRole("link", { name: /ユーザー管理/ })
+  ).toBeVisible();
   await adminPage.getByRole("link", { name: "団体審査一覧" }).click();
   await expect(adminPage).toHaveURL(/\/admin\/organizations$/);
   await adminContext.close();

--- a/app/e2e/common-boundaries.spec.ts
+++ b/app/e2e/common-boundaries.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Browser, type Page } from "@playwright/test";
 
 const AUTH_STATE = {
   participant: "playwright/.auth/participant.json",
+  participantDiagnosis: "playwright/.auth/participant-diagnosis.json",
   participantLogout: "playwright/.auth/participant-logout.json",
   organization: "playwright/.auth/organization.json",
   organizationPendingReadonly:
@@ -171,10 +172,36 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
   });
   const participantPage = await participantContext.newPage();
   await participantPage.goto("/");
+  await expect(
+    participantPage.getByRole("heading", { name: "性格傾向チェックを始める" })
+  ).toHaveCount(0);
   await participantPage.getByRole("button", { name: "メニューを開く" }).click();
   await participantPage.getByRole("link", { name: "マイページ" }).click();
   await expect(participantPage).toHaveURL(/\/mypage$/);
   await participantContext.close();
+
+  const participantDiagnosisContext = await browser.newContext({
+    storageState: AUTH_STATE.participantDiagnosis,
+    viewport,
+  });
+  const participantDiagnosisPage = await participantDiagnosisContext.newPage();
+  await participantDiagnosisPage.goto("/");
+  await expect(
+    participantDiagnosisPage.getByRole("heading", {
+      name: "性格傾向チェックを始める",
+    })
+  ).toHaveCount(0);
+  await participantDiagnosisPage
+    .getByRole("button", { name: "メニューを開く" })
+    .click();
+  await participantDiagnosisPage.getByRole("link", { name: "マイページ" }).click();
+  await expect(participantDiagnosisPage).toHaveURL(/\/mypage$/);
+  await expect(
+    participantDiagnosisPage.getByRole("heading", {
+      name: "性格傾向チェックを始める",
+    })
+  ).toBeVisible();
+  await participantDiagnosisContext.close();
 
   const organizationContext = await browser.newContext({
     storageState: AUTH_STATE.organization,
@@ -182,6 +209,9 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
   });
   const organizationPage = await organizationContext.newPage();
   await organizationPage.goto("/");
+  await expect(
+    organizationPage.getByRole("heading", { name: "性格傾向チェックを始める" })
+  ).toHaveCount(0);
   await organizationPage.getByRole("button", { name: "メニューを開く" }).click();
   await organizationPage.getByRole("link", { name: "ダッシュボード" }).click();
   await expect(organizationPage).toHaveURL(/\/dashboard$/);
@@ -192,6 +222,10 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
     viewport,
   });
   const adminPage = await adminContext.newPage();
+  await adminPage.goto("/");
+  await expect(
+    adminPage.getByRole("heading", { name: "性格傾向チェックを始める" })
+  ).toHaveCount(0);
   await adminPage.goto("/admin");
   await adminPage.getByRole("link", { name: "団体審査一覧" }).click();
   await expect(adminPage).toHaveURL(/\/admin\/organizations$/);

--- a/app/e2e/common-boundaries.spec.ts
+++ b/app/e2e/common-boundaries.spec.ts
@@ -46,6 +46,11 @@ test("C-E2: ロール越境を認可マトリクスで拒否する", async ({ br
     const { context, page } = await openAuthenticatedPage(browser, storageState);
     await page.goto(path);
     await expectForbidden(page, hiddenText);
+    await page.getByRole("link", { name: "トップへ戻る" }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(
+      page.getByRole("heading", { name: "このページにはアクセスできません" })
+    ).toHaveCount(0);
     await context.close();
   }
 });

--- a/app/e2e/common-boundaries.spec.ts
+++ b/app/e2e/common-boundaries.spec.ts
@@ -181,6 +181,12 @@ test("C-E7: モバイル表示で各ロールの主要導線を操作できる",
   await expect(
     participantPage.getByRole("link", { name: /性格傾向チェック/ })
   ).toBeVisible();
+  await participantPage.getByRole("link", { name: /性格傾向チェック/ }).click();
+  await expect(participantPage).toHaveURL(/\/diagnosis$/);
+  await expect(
+    participantPage.getByRole("heading", { name: "性格傾向チェック" })
+  ).toBeVisible();
+  await participantPage.goto("/");
   await participantPage.getByRole("link", { name: "マイページ" }).click();
   await expect(participantPage).toHaveURL(/\/mypage$/);
   await participantContext.close();

--- a/app/src/app/components/AuthenticatedHome.tsx
+++ b/app/src/app/components/AuthenticatedHome.tsx
@@ -305,50 +305,6 @@ export function AuthenticatedHome({
         </div>
       </section>
 
-      {/* 利用の流れ */}
-      <section className="flex flex-col items-center gap-8 py-12">
-        <h2 className="text-base text-text-dark">利用の流れ</h2>
-        <div className="grid w-full grid-cols-1 gap-8 md:grid-cols-3">
-          {[
-            {
-              step: 1,
-              color: "bg-primary",
-              title: "性格傾向チェック",
-              description:
-                "簡易診断（15問）または全50問の質問で、5つの性格特性の傾向を確認します",
-            },
-            {
-              step: 2,
-              color: "bg-primary-dark",
-              title: "マッチング",
-              description:
-                "興味分野・地域・日程などをもとに、性格の傾向も参考にしておすすめを表示します",
-            },
-            {
-              step: 3,
-              color: "bg-text-dark",
-              title: "参加申し込み",
-              description:
-                "気になる活動があれば、詳細を確認して参加申し込みができます",
-            },
-          ].map((item) => (
-            <div
-              key={item.step}
-              className="flex flex-col items-center gap-4 text-center"
-            >
-              <div
-                className={`flex size-12 items-center justify-center rounded-full ${item.color} text-base font-medium text-white`}
-              >
-                {item.step}
-              </div>
-              <h3 className="text-base text-text-dark">{item.title}</h3>
-              <p className="text-sm leading-5 text-text-body">
-                {item.description}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
     </main>
   );
 }

--- a/app/src/app/components/AuthenticatedHome.tsx
+++ b/app/src/app/components/AuthenticatedHome.tsx
@@ -1,13 +1,250 @@
-import { Heart, Sparkles } from "lucide-react";
+import Link from "next/link";
+import {
+  BadgeCheck,
+  Brain,
+  Building2,
+  FileCheck2,
+  Heart,
+  History,
+  Inbox,
+  LayoutDashboard,
+  MessageSquarePlus,
+  Plus,
+  Search,
+  Sparkles,
+  User as UserIcon,
+  Users,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { User } from "@supabase/supabase-js";
+
+export type AuthenticatedHomeRole = "participant" | "organization" | "admin" | null;
 
 interface AuthenticatedHomeProps {
   user: User;
+  role: AuthenticatedHomeRole;
+  onboardingCompleted: boolean;
+  organizationVerified?: boolean;
 }
 
-export function AuthenticatedHome({ user }: AuthenticatedHomeProps) {
+interface FeatureLink {
+  href: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  primary?: boolean;
+}
+
+interface HomeDashboardContent {
+  title: string;
+  description: string;
+  links: FeatureLink[];
+}
+
+const PARTICIPANT_LINKS: FeatureLink[] = [
+  {
+    href: "/mypage",
+    label: "マイページ",
+    description: "プロフィール、応募状況、参加証明書をまとめて確認します。",
+    icon: UserIcon,
+    primary: true,
+  },
+  {
+    href: "/recommendations",
+    label: "おすすめ案件",
+    description: "興味や地域に合うボランティア募集を探します。",
+    icon: Search,
+  },
+  {
+    href: "/diagnosis",
+    label: "性格傾向チェック",
+    description: "活動スタイルの参考になる診断を受けます。",
+    icon: Brain,
+  },
+  {
+    href: "/mypage/approaches",
+    label: "受信アプローチ",
+    description: "団体から届いたアプローチを確認します。",
+    icon: Inbox,
+  },
+  {
+    href: "/mypage/certificates",
+    label: "参加証明書",
+    description: "活動完了後の証明書申請と発行状況を確認します。",
+    icon: FileCheck2,
+  },
+];
+
+const ORGANIZATION_LINKS: FeatureLink[] = [
+  {
+    href: "/dashboard",
+    label: "ダッシュボード",
+    description: "募集案件と団体の状態を確認します。",
+    icon: LayoutDashboard,
+    primary: true,
+  },
+  {
+    href: "/dashboard/opportunities/new",
+    label: "新しい案件を作成",
+    description: "参加者を募集するボランティア案件を登録します。",
+    icon: Plus,
+  },
+  {
+    href: "/dashboard/participants",
+    label: "おすすめ参加者",
+    description: "募集内容に合う参加者候補を確認します。",
+    icon: Users,
+  },
+  {
+    href: "/dashboard/approaches",
+    label: "アプローチ履歴",
+    description: "参加者へ送ったアプローチの履歴を確認します。",
+    icon: MessageSquarePlus,
+  },
+  {
+    href: "/dashboard/certificates",
+    label: "証明書申請",
+    description: "参加証明書の申請内容を確認し発行します。",
+    icon: FileCheck2,
+  },
+];
+
+const ADMIN_LINKS: FeatureLink[] = [
+  {
+    href: "/admin",
+    label: "管理ダッシュボード",
+    description: "ユーザー数、マッチング数、審査待ち件数を確認します。",
+    icon: LayoutDashboard,
+    primary: true,
+  },
+  {
+    href: "/admin/organizations",
+    label: "団体審査一覧",
+    description: "登録団体の審査と承認状況を管理します。",
+    icon: BadgeCheck,
+  },
+  {
+    href: "/admin/users",
+    label: "ユーザー管理",
+    description: "利用者の状態確認と凍結管理を行います。",
+    icon: Users,
+  },
+  {
+    href: "/admin/reviews/history",
+    label: "審査履歴",
+    description: "団体審査の対応履歴を確認します。",
+    icon: History,
+  },
+];
+
+function getDashboardContent({
+  role,
+  onboardingCompleted,
+  organizationVerified,
+}: Pick<
+  AuthenticatedHomeProps,
+  "role" | "onboardingCompleted" | "organizationVerified"
+>): HomeDashboardContent {
+  if (role === "admin") {
+    return {
+      title: "管理者メニュー",
+      description: "運営管理で使う機能へ移動できます。",
+      links: ADMIN_LINKS,
+    };
+  }
+
+  if (role === "organization") {
+    if (!onboardingCompleted) {
+      return {
+        title: "団体登録を完了してください",
+        description: "募集機能を使うには、団体プロフィールの登録が必要です。",
+        links: [
+          {
+            href: "/onboarding/organization",
+            label: "団体プロフィールを登録",
+            description: "団体情報を入力して審査へ進みます。",
+            icon: Building2,
+            primary: true,
+          },
+        ],
+      };
+    }
+
+    if (!organizationVerified) {
+      return {
+        title: "団体審査の状況",
+        description: "審査完了までは募集機能の利用が制限されます。",
+        links: [
+          {
+            href: "/onboarding/pending",
+            label: "審査状況を確認",
+            description: "団体プロフィールの審査状態を確認します。",
+            icon: BadgeCheck,
+            primary: true,
+          },
+        ],
+      };
+    }
+
+    return {
+      title: "募集団体メニュー",
+      description: "募集、参加者確認、証明書発行の機能へ移動できます。",
+      links: ORGANIZATION_LINKS,
+    };
+  }
+
+  if (role === "participant") {
+    if (!onboardingCompleted) {
+      return {
+        title: "応募者登録を完了してください",
+        description: "応募機能を使うには、参加者プロフィールの登録が必要です。",
+        links: [
+          {
+            href: "/onboarding/participant",
+            label: "参加者プロフィールを登録",
+            description: "希望地域などを入力して利用を開始します。",
+            icon: UserIcon,
+            primary: true,
+          },
+        ],
+      };
+    }
+
+    return {
+      title: "応募者メニュー",
+      description: "応募者として使える機能へ移動できます。",
+      links: PARTICIPANT_LINKS,
+    };
+  }
+
+  return {
+    title: "利用を開始してください",
+    description: "アカウント種別を選ぶと、使える機能が表示されます。",
+    links: [
+      {
+        href: "/onboarding/role",
+        label: "アカウント種別を選択",
+        description: "応募者または募集団体として利用を開始します。",
+        icon: UserIcon,
+        primary: true,
+      },
+    ],
+  };
+}
+
+export function AuthenticatedHome({
+  user,
+  role,
+  onboardingCompleted,
+  organizationVerified = false,
+}: AuthenticatedHomeProps) {
   const displayName =
     user.user_metadata?.full_name ?? user.email ?? "ゲスト";
+  const dashboardContent = getDashboardContent({
+    role,
+    onboardingCompleted,
+    organizationVerified,
+  });
 
   return (
     <main className="mx-auto max-w-3xl px-6 pt-6">
@@ -30,6 +267,42 @@ export function AuthenticatedHome({ user }: AuthenticatedHomeProps) {
         <p className="max-w-md text-center text-base leading-7 text-text-body">
           あなたの興味や傾向に合ったボランティア活動を見つけましょう
         </p>
+      </section>
+
+      <section className="flex flex-col gap-4 py-6">
+        <div>
+          <h2 className="text-lg font-bold text-text-dark">
+            {dashboardContent.title}
+          </h2>
+          <p className="mt-1 text-sm leading-6 text-text-body">
+            {dashboardContent.description}
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {dashboardContent.links.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`group flex min-h-28 items-start gap-3 rounded-[10px] border p-4 shadow-sm transition-shadow hover:shadow-md ${
+                item.primary
+                  ? "border-primary/30 bg-primary/5"
+                  : "border-card-border bg-white"
+              }`}
+            >
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                <item.icon className="size-5 text-primary" />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-text-dark group-hover:text-primary">
+                  {item.label}
+                </h3>
+                <p className="mt-1 text-sm leading-5 text-text-body">
+                  {item.description}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
       </section>
 
       {/* 利用の流れ */}

--- a/app/src/app/components/AuthenticatedHome.tsx
+++ b/app/src/app/components/AuthenticatedHome.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-import { Brain, ArrowRight, Heart, Sparkles } from "lucide-react";
+import { Heart, Sparkles } from "lucide-react";
 import type { User } from "@supabase/supabase-js";
 
 interface AuthenticatedHomeProps {
@@ -31,43 +30,6 @@ export function AuthenticatedHome({ user }: AuthenticatedHomeProps) {
         <p className="max-w-md text-center text-base leading-7 text-text-body">
           あなたの興味や傾向に合ったボランティア活動を見つけましょう
         </p>
-      </section>
-
-      {/* 診断カードセクション */}
-      <section className="flex flex-col gap-6 py-6">
-        <h2 className="text-base font-medium text-text-dark">性格傾向チェックを始める</h2>
-        <Link
-          href="/diagnosis"
-          className="group flex flex-col gap-4 rounded-[10px] border border-primary/30 bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
-        >
-          <div className="flex items-center gap-3">
-            <Brain className="size-8 text-primary" />
-            <div>
-              <h3 className="text-xl font-bold tracking-tight text-text-dark">
-                性格傾向チェック
-              </h3>
-              <p className="text-sm text-text-body">
-                簡易診断（15問・約2分）/ 全50問（約5〜8分）から選べます
-              </p>
-            </div>
-          </div>
-          <ul className="flex flex-col gap-2">
-            {[
-              "世界中で使われている性格研究をもとに設計",
-              "5つの性格特性の傾向を確認",
-              "おすすめ案件の並び順の参考になります",
-            ].map((item) => (
-              <li key={item} className="flex items-center gap-2">
-                <span className="size-2 shrink-0 rounded-full bg-primary" />
-                <span className="text-sm text-text-dark">{item}</span>
-              </li>
-            ))}
-          </ul>
-          <div className="mt-auto flex items-center gap-1 text-sm font-medium text-primary group-hover:underline">
-            診断を始める
-            <ArrowRight className="size-4" />
-          </div>
-        </Link>
       </section>
 
       {/* 利用の流れ */}

--- a/app/src/app/components/DiagnosisQuestionCopy.test.tsx
+++ b/app/src/app/components/DiagnosisQuestionCopy.test.tsx
@@ -75,6 +75,18 @@ describe("診断設問数コピー", () => {
     expect(screen.queryByRole("link", { name: /管理ダッシュボード/ })).toBeNull();
   });
 
+  it("ログイン後トップでは利用の流れを表示しない", () => {
+    render(
+      <AuthenticatedHome
+        user={user}
+        role="participant"
+        onboardingCompleted
+      />,
+    );
+
+    expect(screen.queryByRole("heading", { name: "利用の流れ" })).toBeNull();
+  });
+
   it("募集団体トップに団体向け機能導線を表示する", () => {
     render(
       <AuthenticatedHome

--- a/app/src/app/components/DiagnosisQuestionCopy.test.tsx
+++ b/app/src/app/components/DiagnosisQuestionCopy.test.tsx
@@ -41,11 +41,81 @@ const oldQuestionCopyPattern = new RegExp(
 
 describe("診断設問数コピー", () => {
   it("ログイン直後のトップでは診断開始カードを表示しない", () => {
-    render(<AuthenticatedHome user={user} />);
+    render(
+      <AuthenticatedHome
+        user={user}
+        role="participant"
+        onboardingCompleted
+      />,
+    );
 
     expect(screen.queryByText("性格傾向チェックを始める")).toBeNull();
     expect(screen.queryByText("診断を始める")).toBeNull();
     expect(screen.queryByText(oldQuestionCopyPattern)).toBeNull();
+  });
+
+  it("応募者トップに利用できる機能導線を表示する", () => {
+    render(
+      <AuthenticatedHome
+        user={user}
+        role="participant"
+        onboardingCompleted
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /マイページ/ }).getAttribute("href")).toBe(
+      "/mypage",
+    );
+    expect(
+      screen.getByRole("link", { name: /おすすめ案件/ }).getAttribute("href"),
+    ).toBe("/recommendations");
+    expect(
+      screen.getByRole("link", { name: /性格傾向チェック/ }).getAttribute("href"),
+    ).toBe("/diagnosis");
+    expect(screen.queryByRole("link", { name: /管理ダッシュボード/ })).toBeNull();
+  });
+
+  it("募集団体トップに団体向け機能導線を表示する", () => {
+    render(
+      <AuthenticatedHome
+        user={user}
+        role="organization"
+        onboardingCompleted
+        organizationVerified
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /ダッシュボード/ }).getAttribute("href"),
+    ).toBe("/dashboard");
+    expect(
+      screen.getByRole("link", { name: /新しい案件を作成/ }).getAttribute("href"),
+    ).toBe("/dashboard/opportunities/new");
+    expect(
+      screen.getByRole("link", { name: /おすすめ参加者/ }).getAttribute("href"),
+    ).toBe("/dashboard/participants");
+    expect(screen.queryByRole("link", { name: /マイページ/ })).toBeNull();
+  });
+
+  it("管理者トップに管理機能導線を表示する", () => {
+    render(
+      <AuthenticatedHome
+        user={user}
+        role="admin"
+        onboardingCompleted
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /管理ダッシュボード/ }).getAttribute("href"),
+    ).toBe("/admin");
+    expect(
+      screen.getByRole("link", { name: /団体審査一覧/ }).getAttribute("href"),
+    ).toBe("/admin/organizations");
+    expect(
+      screen.getByRole("link", { name: /ユーザー管理/ }).getAttribute("href"),
+    ).toBe("/admin/users");
+    expect(screen.queryByRole("link", { name: /マイページ/ })).toBeNull();
   });
 
   it("LPの診断説明で簡易15問・全50問の2モード診断仕様を表示する", () => {

--- a/app/src/app/components/DiagnosisQuestionCopy.test.tsx
+++ b/app/src/app/components/DiagnosisQuestionCopy.test.tsx
@@ -40,17 +40,11 @@ const oldQuestionCopyPattern = new RegExp(
 );
 
 describe("診断設問数コピー", () => {
-  it("ログイン後トップで簡易診断（15問）と全50問の2モード診断仕様を表示する", () => {
+  it("ログイン直後のトップでは診断開始カードを表示しない", () => {
     render(<AuthenticatedHome user={user} />);
 
-    expect(
-      screen.getByText(
-        /簡易診断（15問）または全50問の質問で、5つの性格特性の傾向を確認します/,
-      ),
-    ).toBeDefined();
-    expect(
-      screen.getByText("簡易診断（15問・約2分）/ 全50問（約5〜8分）から選べます"),
-    ).toBeDefined();
+    expect(screen.queryByText("性格傾向チェックを始める")).toBeNull();
+    expect(screen.queryByText("診断を始める")).toBeNull();
     expect(screen.queryByText(oldQuestionCopyPattern)).toBeNull();
   });
 

--- a/app/src/app/diagnosis/page.test.tsx
+++ b/app/src/app/diagnosis/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  getUser: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  maybeSingle: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    mocks.redirect(url);
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mocks.getUser(),
+    },
+    from: (...args: unknown[]) => mocks.from(...args),
+  }),
+}));
+
+vi.mock("@/app/components/Header", () => ({
+  Header: () => <header>ヘッダー</header>,
+}));
+
+vi.mock("./components/DiagnosisWizard", () => ({
+  DiagnosisWizard: () => <div>診断ウィザード</div>,
+}));
+
+import DiagnosisPage from "./page";
+
+describe("DiagnosisPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUser.mockResolvedValue({
+      data: {
+        user: {
+          id: "participant-user-1",
+          user_metadata: {},
+        },
+      },
+    });
+    mocks.maybeSingle.mockResolvedValue({
+      data: { role: "participant" },
+    });
+    mocks.eq.mockReturnValue({ maybeSingle: mocks.maybeSingle });
+    mocks.select.mockReturnValue({ eq: mocks.eq });
+    mocks.from.mockReturnValue({ select: mocks.select });
+  });
+
+  it("metadata role が無くても DB role が participant なら診断画面を表示する", async () => {
+    const page = await DiagnosisPage();
+    render(page);
+
+    expect(screen.getByText("診断ウィザード")).toBeDefined();
+    expect(mocks.redirect).not.toHaveBeenCalled();
+    expect(mocks.from).toHaveBeenCalledWith("m_user");
+    expect(mocks.select).toHaveBeenCalledWith("role");
+    expect(mocks.eq).toHaveBeenCalledWith("id", "participant-user-1");
+  });
+});

--- a/app/src/app/diagnosis/page.tsx
+++ b/app/src/app/diagnosis/page.tsx
@@ -12,11 +12,21 @@ import { DiagnosisWizard } from "./components/DiagnosisWizard";
  */
 export default async function DiagnosisPage() {
   let user = null;
+  let role: unknown = null;
 
   try {
     const supabase = await createClient();
     const { data } = await supabase.auth.getUser();
     user = data.user;
+
+    if (user) {
+      const { data: account } = await supabase
+        .from("m_user")
+        .select("role")
+        .eq("id", user.id)
+        .maybeSingle();
+      role = account?.role;
+    }
   } catch (err) {
     console.error("[DiagnosisPage] Supabase接続エラー:", err);
   }
@@ -26,8 +36,7 @@ export default async function DiagnosisPage() {
     redirect("/login");
   }
 
-  // 参加者ロールチェック（proxy の user_metadata 検証と同じ基準を利用）
-  const role = (user.user_metadata as Record<string, unknown>).role as string | undefined;
+  // 参加者ロールチェック（自己更新可能な metadata ではなく DB role を利用）
   if (role !== "participant") {
     redirect("/");
   }

--- a/app/src/app/mypage/page.test.tsx
+++ b/app/src/app/mypage/page.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MyPageData } from "@/lib/mypage/types";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  getUser: vi.fn(),
+  fetchMyPageData: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    mocks.redirect(url);
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: () => mocks.getUser(),
+    },
+  }),
+}));
+
+vi.mock("@/app/components/Header", () => ({
+  Header: () => <header>ヘッダー</header>,
+}));
+
+vi.mock("./DeleteAccountForm", () => ({
+  DeleteAccountForm: () => <div>削除フォーム</div>,
+}));
+
+vi.mock("@/lib/mypage/actions", () => ({
+  fetchMyPageData: (...args: unknown[]) => mocks.fetchMyPageData(...args),
+}));
+
+import MyPage from "./page";
+
+const profile: NonNullable<MyPageData["profile"]> = {
+  id: "participant-1",
+  name: "参加者テスト",
+  region: "東京都",
+  diagnosis_completed: false,
+  diagnosis_style_type_label: null,
+  diagnosis_answered_at: null,
+};
+
+describe("MyPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+    mocks.fetchMyPageData.mockResolvedValue({
+      profile,
+      applications: [],
+      alert: null,
+    } satisfies MyPageData);
+  });
+
+  it("参加者登録後のマイページに性格傾向チェック開始カードを表示する", async () => {
+    const page = await MyPage();
+    render(page);
+
+    expect(
+      screen.getByRole("heading", { name: "性格傾向チェックを始める" }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: /診断を始める/ }).getAttribute("href"),
+    ).toBe("/diagnosis");
+    expect(
+      screen.getByText("簡易診断（15問・約2分）/ 全50問（約5〜8分）から選べます"),
+    ).toBeDefined();
+  });
+
+  it("参加者登録前は性格傾向チェック開始カードを表示しない", async () => {
+    mocks.fetchMyPageData.mockResolvedValueOnce({
+      profile: null,
+      applications: [],
+      alert: null,
+    } satisfies MyPageData);
+
+    const page = await MyPage();
+    render(page);
+
+    expect(screen.queryByText("性格傾向チェックを始める")).toBeNull();
+    expect(screen.queryByText("診断を始める")).toBeNull();
+  });
+
+  it("未ログインユーザーはログイン画面へリダイレクトする", async () => {
+    mocks.getUser.mockResolvedValueOnce({ data: { user: null } });
+
+    await expect(MyPage()).rejects.toThrow("NEXT_REDIRECT:/login");
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/login");
+    expect(mocks.fetchMyPageData).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/app/mypage/page.tsx
+++ b/app/src/app/mypage/page.tsx
@@ -3,6 +3,7 @@ import {
   User,
   MapPin,
   Brain,
+  ArrowRight,
   ClipboardList,
   Search,
   Clock,
@@ -74,10 +75,7 @@ export default async function MyPage() {
   const profileActionLabel = profile ? "編集" : "登録";
   const diagnosisActionHref = profile?.diagnosis_completed
     ? "/diagnosis/result"
-    : "/diagnosis";
-  const diagnosisActionLabel = profile?.diagnosis_completed
-    ? "診断結果を見る"
-    : "性格診断を受ける";
+    : null;
 
   return (
     <div className="min-h-screen bg-background font-sans">
@@ -167,17 +165,65 @@ export default async function MyPage() {
           </CardContent>
         </Card>
 
+        {profile && !profile.diagnosis_completed && (
+          <section
+            aria-labelledby="diagnosis-start-title"
+            className="mb-8 flex flex-col gap-4"
+          >
+            <h2
+              id="diagnosis-start-title"
+              className="text-lg font-bold text-text-dark"
+            >
+              性格傾向チェックを始める
+            </h2>
+            <Link
+              href="/diagnosis"
+              className="group flex flex-col gap-4 rounded-[10px] border border-primary/30 bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
+            >
+              <div className="flex items-center gap-3">
+                <Brain className="size-8 text-primary" />
+                <div>
+                  <h3 className="text-xl font-bold tracking-tight text-text-dark">
+                    性格傾向チェック
+                  </h3>
+                  <p className="text-sm text-text-body">
+                    簡易診断（15問・約2分）/ 全50問（約5〜8分）から選べます
+                  </p>
+                </div>
+              </div>
+              <ul className="flex flex-col gap-2">
+                {[
+                  "世界中で使われている性格研究をもとに設計",
+                  "5つの性格特性の傾向を確認",
+                  "おすすめ案件の並び順の参考になります",
+                ].map((item) => (
+                  <li key={item} className="flex items-center gap-2">
+                    <span className="size-2 shrink-0 rounded-full bg-primary" />
+                    <span className="text-sm text-text-dark">{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-auto flex items-center gap-1 text-sm font-medium text-primary group-hover:underline">
+                診断を始める
+                <ArrowRight className="size-4" />
+              </div>
+            </Link>
+          </section>
+        )}
+
         {/* アクションリンク */}
         <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <Link
-            href={diagnosisActionHref}
-            className="flex items-center gap-3 rounded-[10px] border border-card-border bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
-          >
-            <Brain className="size-5 text-primary" />
-            <span className="text-sm font-medium text-text-dark">
-              {diagnosisActionLabel}
-            </span>
-          </Link>
+          {diagnosisActionHref && (
+            <Link
+              href={diagnosisActionHref}
+              className="flex items-center gap-3 rounded-[10px] border border-card-border bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+            >
+              <Brain className="size-5 text-primary" />
+              <span className="text-sm font-medium text-text-dark">
+                診断結果を見る
+              </span>
+            </Link>
+          )}
           <Link
             href="/recommendations"
             className="flex items-center gap-3 rounded-[10px] border border-card-border bg-white p-4 shadow-sm transition-shadow hover:shadow-md"

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,5 +1,8 @@
 import { Header } from "./components/Header";
-import { AuthenticatedHome } from "./components/AuthenticatedHome";
+import {
+  AuthenticatedHome,
+  type AuthenticatedHomeRole,
+} from "./components/AuthenticatedHome";
 import { Reveal } from "./components/lp/Reveal";
 import { LPHeroSection } from "./components/lp/LPHeroSection";
 import { DiagnosisTypesCarousel } from "./components/lp/DiagnosisTypesCarousel";
@@ -14,12 +17,53 @@ import { LPBottomCTA } from "./components/lp/LPBottomCTA";
 import { LPFooter } from "./components/lp/LPFooter";
 import { createClient } from "@/lib/supabase/server";
 
+function isAuthenticatedHomeRole(value: unknown): value is Exclude<AuthenticatedHomeRole, null> {
+  return value === "participant" || value === "organization" || value === "admin";
+}
+
+function isOrganizationApproved(profile: {
+  verified?: boolean | null;
+  review_status?: string | null;
+} | null): boolean {
+  return !!profile?.verified || profile?.review_status === "approved";
+}
+
 export default async function Home() {
   let user = null;
+  let role: AuthenticatedHomeRole = null;
+  let onboardingCompleted = false;
+  let organizationVerified = false;
+
   try {
     const supabase = await createClient();
     const { data } = await supabase.auth.getUser();
     user = data.user;
+
+    if (user) {
+      const metadata = user.user_metadata as Record<string, unknown>;
+      onboardingCompleted = !!metadata.onboarding_completed;
+
+      const { data: account } = await supabase
+        .from("m_user")
+        .select("role")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      if (isAuthenticatedHomeRole(account?.role)) {
+        role = account.role;
+      } else if (isAuthenticatedHomeRole(metadata.role)) {
+        role = metadata.role;
+      }
+
+      if (role === "organization") {
+        const { data: organizationProfile } = await supabase
+          .from("m_organization_profile")
+          .select("verified, review_status")
+          .eq("user_id", user.id)
+          .maybeSingle();
+        organizationVerified = isOrganizationApproved(organizationProfile);
+      }
+    }
   } catch {
     // Supabase未設定・接続エラー時はログインなしで表示
   }
@@ -28,7 +72,14 @@ export default async function Home() {
     <div className="min-h-screen bg-background font-sans">
       <Header />
 
-      {user && <AuthenticatedHome user={user} />}
+      {user && (
+        <AuthenticatedHome
+          user={user}
+          role={role}
+          onboardingCompleted={onboardingCompleted}
+          organizationVerified={organizationVerified}
+        />
+      )}
 
       {!user && (
         <main className="relative mx-auto w-full max-w-7xl overflow-x-hidden px-4 pt-8 pb-20 sm:px-6 lg:px-8">

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -88,6 +88,18 @@ describe("proxy", () => {
     expect(response.headers.get("location")).toBeNull();
   });
 
+  it("認証済みでもトップページは公開ページとして通過する", async () => {
+    const request = createRequest("/");
+    mockAuthenticatedSession(request, "missing-role-1");
+    mocks.maybeSingle.mockResolvedValueOnce({ data: null });
+
+    const response = await proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
   it("未認証の保護ルートはログインへリダイレクトする", async () => {
     const request = createRequest("/dashboard");
     mockGuestSession(request);

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -131,6 +131,27 @@ describe("proxy", () => {
     expect(mocks.eq).toHaveBeenCalledWith("id", "active-1");
   });
 
+  it("metadata role が無くても DB role があれば保護ルートを通過する", async () => {
+    const request = createRequest("/mypage");
+    mocks.updateSession.mockResolvedValue({
+      response: NextResponse.next({ request }),
+      user: {
+        id: "metadata-role-missing-1",
+        user_metadata: {
+          onboarding_completed: true,
+        },
+      },
+    });
+    mocks.maybeSingle.mockResolvedValueOnce({
+      data: { is_active: true, role: "participant" },
+    });
+
+    const response = await proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
   it("凍結ユーザーは保護ルートで強制サインアウトされる", async () => {
     const request = createRequest("/mypage");
     mockAuthenticatedSession(request, "suspended-1");

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -179,17 +179,10 @@ export async function proxy(request: NextRequest) {
   const metadata = user.user_metadata as Record<string, unknown>;
   const rawRole = metadata.role;
 
-  // ロール未選択 → /onboarding/role
-  if (!isAppRole(rawRole)) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/onboarding/role";
-    return redirectWithCookies(url, response);
-  }
-
   // 認可には自己更新可能な metadata ではなく DB のロールだけを使う
   if (!isAppRole(databaseRole)) {
     const url = request.nextUrl.clone();
-    url.pathname = "/forbidden";
+    url.pathname = isAppRole(rawRole) ? "/forbidden" : "/onboarding/role";
     return redirectWithCookies(url, response);
   }
   const role = databaseRole;

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -113,17 +113,13 @@ export async function proxy(request: NextRequest) {
     return response;
   }
 
-  // --- パブリック（/）: 未認証ならスルー、認証済みならロール/オンボーディングチェックを実施 ---
-  const isPublicPath = PUBLIC_PATHS.has(pathname);
-  if (isPublicPath) {
-    if (!user) {
-      return response;
-    }
-    // 認証済みユーザーは下のロール・オンボーディングチェックに進む
+  // --- パブリック（/）: 認証状態に関係なくスルー ---
+  if (PUBLIC_PATHS.has(pathname)) {
+    return response;
   }
 
   // --- 保護対象外の未知URLなどは Next.js の 404 判定へ通す ---
-  if (!isPublicPath && !isProtectedPath(pathname)) {
+  if (!isProtectedPath(pathname)) {
     return response;
   }
 
@@ -197,13 +193,6 @@ export async function proxy(request: NextRequest) {
     return redirectWithCookies(url, response);
   }
   const role = databaseRole;
-
-  // 管理者: トップアクセス時は管理ダッシュボードへ
-  if (role === "admin" && pathname === "/") {
-    const url = request.nextUrl.clone();
-    url.pathname = "/admin/organizations";
-    return redirectWithCookies(url, response);
-  }
 
   // オンボーディング未完了 → /onboarding/{role}
   if (role !== "admin" && !metadata.onboarding_completed) {


### PR DESCRIPTION
## Summary

- forbidden ページの「トップへ戻る」からトップページへ戻れるように proxy の公開ルート判定を修正
- 認証済みユーザーでもトップページが公開ルートとして通過する回帰UTを追加
- ロール越境時の forbidden 画面からトップへ戻る E2E 回帰確認を追加

## Verification

- cd app && npx vitest run src/proxy.test.ts: 成功
- cd app && npm run lint: 成功
- cd app && npm run build: 成功
- cd app && npm test: 成功（62 files / 452 tests）
- npx playwright test e2e/common-boundaries.spec.ts -g "C-E2" --project=chromium: 成功（19 passed）

## Notes

- このブランチは細かな修正点を集約する用途として draft PR にしています。
- E2E 実行のためローカル Supabase を使用しました。
