### PR TITLE
chore: clean up worktree local environments

### DIFF
--- a/.agent-shared/scripts/codex-worktree-cleanup.sh
+++ b/.agent-shared/scripts/codex-worktree-cleanup.sh
@@ -5,6 +5,75 @@ log() {
   printf '[codex-worktree-cleanup] %s\n' "$*"
 }
 
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+has_worktree_docker_compose_resources() {
+  local container_ids
+
+  if ! command_exists docker; then
+    log "Docker が見つからないため、Docker Compose の削除をスキップします。"
+    return 1
+  fi
+
+  if ! container_ids="$(docker ps -aq --filter "label=com.docker.compose.project.working_dir=$repo_root" 2>/dev/null)"; then
+    log "Docker daemon に接続できないため、Docker Compose の削除をスキップします。"
+    return 1
+  fi
+
+  [ -n "$container_ids" ]
+}
+
+cleanup_docker_compose() {
+  if ! has_worktree_docker_compose_resources; then
+    log "この worktree で作成された Docker Compose 環境は見つかりません。"
+    return 0
+  fi
+
+  log "この worktree で作成された Docker Compose 環境を削除します。"
+  if docker compose down -v; then
+    log "Docker Compose 環境を削除しました。"
+  else
+    log "Docker Compose 環境の削除に失敗しました。"
+    return 1
+  fi
+}
+
+has_supabase_local_state() {
+  local temp_dir="$repo_root/supabase/.temp"
+
+  [ -d "$temp_dir" ] && find "$temp_dir" -mindepth 1 ! -name cli-latest -print -quit | grep -q .
+}
+
+cleanup_supabase() {
+  if ! command_exists supabase; then
+    log "Supabase CLI が見つからないため、Supabase ローカル環境の削除をスキップします。"
+    return 0
+  fi
+
+  if ! has_supabase_local_state; then
+    log "この worktree で作成された Supabase ローカル状態は見つかりません。"
+    return 0
+  fi
+
+  log "この worktree の Supabase ローカル環境をバックアップなしで削除します。"
+  if (
+    cd "$repo_root"
+    set -a
+    if [ -f ./app/.env.local ]; then
+      . ./app/.env.local
+    fi
+    set +a
+    supabase stop --no-backup
+  ); then
+    log "Supabase ローカル環境を削除しました。"
+  else
+    log "Supabase ローカル環境の削除に失敗しました。"
+    return 1
+  fi
+}
+
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 cd "$repo_root"
@@ -12,5 +81,6 @@ cd "$repo_root"
 log "Repository: $repo_root"
 log "Codex がこの後 worktree ディレクトリ全体を削除します。"
 log "worktree 内の node_modules やビルド成果物は、ディレクトリ削除に含まれます。"
-log "Docker / Supabase / dev server は setup script で起動しないため、ここでは停止処理を行いません。"
+cleanup_docker_compose
+cleanup_supabase
 log "クリーンアップ前処理が完了しました。"

--- a/.agent-shared/scripts/codex-worktree-cleanup.test.sh
+++ b/.agent-shared/scripts/codex-worktree-cleanup.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+script_under_test="$script_dir/codex-worktree-cleanup.sh"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq "$expected" "$file"; then
+    printf 'Expected to find: %s\n' "$expected" >&2
+    printf 'Actual log:\n' >&2
+    cat "$file" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq "$unexpected" "$file"; then
+    printf 'Expected not to find: %s\n' "$unexpected" >&2
+    printf 'Actual log:\n' >&2
+    cat "$file" >&2
+    return 1
+  fi
+}
+
+prepare_repo() {
+  local repo="$1"
+
+  mkdir -p "$repo"/{.agent-shared/scripts,supabase}
+  cp "$script_under_test" "$repo/.agent-shared/scripts/codex-worktree-cleanup.sh"
+  git -C "$repo" init -q
+}
+
+write_fake_commands() {
+  local bin_dir="$1"
+  local call_log="$2"
+  local docker_has_worktree_resource="$3"
+
+  mkdir -p "$bin_dir"
+
+  cat > "$bin_dir/docker" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\n' "\$*" >> "$call_log"
+if [ "\${1:-}" = "ps" ]; then
+  if [ "$docker_has_worktree_resource" = "yes" ]; then
+    printf 'container-1\n'
+  fi
+  exit 0
+fi
+exit 0
+EOF
+
+  cat > "$bin_dir/supabase" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'supabase %s\n' "\$*" >> "$call_log"
+exit 0
+EOF
+
+  chmod +x "$bin_dir/docker" "$bin_dir/supabase"
+}
+
+run_cleanup() {
+  local repo="$1"
+  local bin_dir="$2"
+
+  (cd "$repo" && PATH="$bin_dir:$PATH" "$repo/.agent-shared/scripts/codex-worktree-cleanup.sh" >/dev/null)
+}
+
+test_stops_docker_compose_for_current_worktree() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  repo="$(cd "$repo" && pwd -P)"
+  write_fake_commands "$bin_dir" "$call_log" yes
+
+  run_cleanup "$repo" "$bin_dir"
+
+  assert_contains "$call_log" "docker ps -aq --filter label=com.docker.compose.project.working_dir=$repo"
+  assert_contains "$call_log" "docker compose down -v"
+}
+
+test_skips_docker_compose_without_current_worktree_resource() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  repo="$(cd "$repo" && pwd -P)"
+  write_fake_commands "$bin_dir" "$call_log" no
+
+  run_cleanup "$repo" "$bin_dir"
+
+  assert_contains "$call_log" "docker ps -aq --filter label=com.docker.compose.project.working_dir=$repo"
+  assert_not_contains "$call_log" "docker compose down -v"
+}
+
+test_stops_supabase_when_temp_state_exists() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  repo="$(cd "$repo" && pwd -P)"
+  mkdir -p "$repo/supabase/.temp"
+  touch "$repo/supabase/.temp/pooler-url"
+  write_fake_commands "$bin_dir" "$call_log" no
+
+  run_cleanup "$repo" "$bin_dir"
+
+  assert_contains "$call_log" "supabase stop --no-backup"
+}
+
+test_skips_supabase_without_temp_state() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  repo="$(cd "$repo" && pwd -P)"
+  write_fake_commands "$bin_dir" "$call_log" no
+
+  run_cleanup "$repo" "$bin_dir"
+
+  assert_not_contains "$call_log" "supabase stop --no-backup"
+}
+
+test_stops_docker_compose_for_current_worktree
+test_skips_docker_compose_without_current_worktree_resource
+test_stops_supabase_when_temp_state_exists
+test_skips_supabase_without_temp_state
+
+printf 'codex-worktree-cleanup tests passed\n'


### PR DESCRIPTION
## Summary

- Codex worktree cleanup で、現在の worktree に紐づく Docker Compose 環境を検出して `docker compose down -v` するようにしました。
- `supabase/.temp` にローカル状態がある場合、Supabase CLI で `supabase stop --no-backup` を実行するようにしました。
- 実 Docker / Supabase を触らずに cleanup 条件を検証する bash テストを追加しました。

## Verification

- `bash -n .agent-shared/scripts/codex-worktree-cleanup.sh .agent-shared/scripts/codex-worktree-cleanup.test.sh`: 成功
- `bash .agent-shared/scripts/codex-worktree-cleanup.test.sh`: 成功
- `git diff --check`: 成功
- `shellcheck`: 未実行（ローカルに未インストール）

## Notes

- Supabase は `project_id = "volunty"` が固定で checkout 間の完全な識別が難しいため、cleanup 対象はこの worktree 内の `supabase/.temp` にローカル状態がある場合に限定しています。