### PR TITLE
fix: redirect auth callbacks to volunty.jp

### DIFF
--- a/app/src/app/(auth)/signup/profile/page.test.tsx
+++ b/app/src/app/(auth)/signup/profile/page.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/lib/supabase/client", () => ({
 describe("SignupProfilePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://volunty.vercel.app/");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://volunty.jp/");
     sessionStorage.clear();
     sessionStorage.setItem(
       SIGNUP_TEMP_KEY,
@@ -62,9 +62,34 @@ describe("SignupProfilePage", () => {
         data: {
           full_name: "山田 太郎",
         },
-        emailRedirectTo: "https://volunty.vercel.app/auth/callback",
+        emailRedirectTo: "https://volunty.jp/auth/callback",
       },
     });
     expect(mocks.push).toHaveBeenCalledWith("/signup/complete");
+  });
+
+  it("本番URLが未設定でもvolunty.jpの認証コールバックURLを使用する", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", undefined);
+    vi.stubEnv("NODE_ENV", "production");
+
+    render(<SignupProfilePage />);
+
+    fireEvent.change(screen.getByLabelText("お名前"), {
+      target: { value: "山田 太郎" },
+    });
+    fireEvent.change(screen.getByLabelText("パスワード"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "登録する" }));
+
+    await waitFor(() => expect(mocks.signUp).toHaveBeenCalled());
+
+    expect(mocks.signUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          emailRedirectTo: "https://volunty.jp/auth/callback",
+        }),
+      })
+    );
   });
 });

--- a/app/src/app/(auth)/signup/profile/page.tsx
+++ b/app/src/app/(auth)/signup/profile/page.tsx
@@ -12,7 +12,7 @@ import { SIGNUP_TEMP_KEY } from "@/app/(auth)/signup/constants";
 
 /** ステップ数に基づくプログレスバー値 */
 const STEP2_PROGRESS = Math.round((2 / 3) * 100);
-const PRODUCTION_SITE_URL = "https://volunty.vercel.app";
+const PRODUCTION_SITE_URL = "https://volunty.jp";
 
 interface SignupTemp {
   email: string;


### PR DESCRIPTION
## Summary

- 本番認証コールバックのフォールバックURLを `https://volunty.jp` に変更
- `NEXT_PUBLIC_SITE_URL` 未設定時の回帰テストを追加
- Supabase AuthのSite URL／許可リダイレクトURLとVercel Production環境変数も `volunty.jp` に更新済み

## Verification

- `npm test` — 83 files / 520 tests passed
- `npm run lint` — passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed（既存のローカル環境変数を使用）
- Supabase local + `npm run test:e2e` — 75 passed
- `https://volunty.jp/login` のGoogle OAuth開始URLで `redirect_to=https://volunty.jp/auth/callback` を確認

## Notes

- 本番のVercel再デプロイはReadyまで確認済みです。