### PR TITLE
ci: Codex Cloud開発フローをCLI優先方式で整備

### DIFF
--- a/.agent-shared/instructions/common.md
+++ b/.agent-shared/instructions/common.md
@@ -14,6 +14,7 @@
 - 実装後に変更点、確認結果、残タスクをまとめる。
 - Codex Cloud の作業ブランチは `codex/<topic>`、Pull Request の base は `main` とする。`main` へのマージは人間が行う。
 - feature ブランチへの push で作成される Vercel Preview を確認し、CI と Codex Review が成功してから PR を完成扱いにする。
+- Codex Cloud のNext.js buildは `cd app && npm run build -- --webpack` を使用する。
 
 ## 基本方針
 

--- a/.agent-shared/instructions/common.md
+++ b/.agent-shared/instructions/common.md
@@ -15,6 +15,8 @@
 - Codex Cloud の作業ブランチは `codex/<topic>`、Pull Request の base は `main` とする。`main` へのマージは人間が行う。
 - feature ブランチへの push で作成される Vercel Preview を確認し、CI と Codex Review が成功してから PR を完成扱いにする。
 - Codex Cloud のNext.js buildは `cd app && npm run build -- --webpack` を使用する。
+- Codex CloudではMCPブリッジを使わずCLIを優先する。ドキュメント検索は `ctx7`、ブラウザ/E2EはPlaywright、DBはPrisma、UTはVitest、lintはESLint、型チェックはTypeScript、コード検索は `rg` / `git grep` を使用する。ローカル環境のネイティブMCP設定は維持する。
+- Codex Cloudではセットアップ済みの `vercel` CLIを使用できるが、Vercel tokenをCloudへ登録せず、Previewデプロイはfeatureブランチへのpushで行う。
 
 ## 基本方針
 

--- a/.agent-shared/instructions/common.md
+++ b/.agent-shared/instructions/common.md
@@ -12,6 +12,8 @@
 - テスト、lint、型チェックを可能な限り実行する。
 - 実装・修正・リファクタリング完了前に `volunty-test-completion-gate` で UT/E2E の追加要否を判定し、必要なテストを追加・実行する。
 - 実装後に変更点、確認結果、残タスクをまとめる。
+- Codex Cloud の作業ブランチは `codex/<topic>`、Pull Request の base は `main` とする。`main` へのマージは人間が行う。
+- feature ブランチへの push で作成される Vercel Preview を確認し、CI と Codex Review が成功してから PR を完成扱いにする。
 
 ## 基本方針
 
@@ -41,3 +43,4 @@
 1. タスクを始める前に上表から関係する skill を選び、必要なものだけ読む。
 2. 新しい恒久的なプロジェクト知識を追加する場合は、AGENTS.md へ長文を戻さず、該当 skill を更新する。
 3. 複数セクションにまたがる作業では、関係する skill を組み合わせて読む。
+4. Codex Cloud の設定・依頼手順は [docs/codex-cloud.md](docs/codex-cloud.md) を参照し、本番シークレットを Cloud に登録しない。

--- a/.agent-shared/skills/volunty-mcp-operations/SKILL.md
+++ b/.agent-shared/skills/volunty-mcp-operations/SKILL.md
@@ -14,9 +14,23 @@ argument-hint: '例: MCP設定を変更 / GitHub MCPトークンの扱い / .mcp
 - GitHub MCP の認証情報は `GITHUB_MCP_TOKEN` 環境変数からのみ注入する。
 - tracked file にトークンや認証情報を書かない。
 
+## Codex Cloud
+
+- Codex Cloudでは `mcpc` やネイティブMCPを使用せず、用途ごとのCLIを直接使用する。
+- Context7はsetup/maintenanceで公式 `ctx7@0.5.7` CLIを使用する。
+  - ライブラリ検索: `ctx7 library <name> '<query>'`
+  - ドキュメント取得: `ctx7 docs <library-id> '<query>'`
+- ブラウザ/E2Eは `cd app && npx playwright`、DBは `cd app && npx prisma` を使用する。
+- UTは `cd app && npx vitest`、lintは `cd app && npx eslint`、型チェックは `cd app && npx tsc` を使用する。
+- Serena相当のコード調査は `rg`、`git grep`、TypeScript、既存テストで行う。
+- GitHub操作とPR作成はCodex Cloud標準のGitHub接続を使用し、GitHub MCPトークンを登録しない。
+- Figma LocalはCloudコンテナから利用できないため使用しない。
+- Vercel token、本番シークレット、その他の認証情報をCloudやtracked fileへ登録しない。
+
 ## 確認ポイント
 
 - MCP 設定を変更する場合は、差分に秘密情報が含まれていないか確認する。
 - `.mcp.json` が意図せず追跡対象になっていないか確認する。
 - `.codex/config.toml` の MCP セクションが `.agent-shared/mcp/servers.json` から再生成されているか確認する。
 - 認証情報を README、docs、設定ファイル、テストデータへ書かない。
+- CloudでContext7を利用する場合は、Agent internet accessを `context7.com` に必要なHTTPメソッドだけ許可する。

--- a/.codex/cloud/cloud-scripts.test.sh
+++ b/.codex/cloud/cloud-scripts.test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fqx "$expected" "$file" || {
+    printf 'Expected to find line: %s\n' "$expected" >&2
+    printf 'Actual log:\n' >&2
+    cat "$file" >&2
+    return 1
+  }
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq "$unexpected" "$file"; then
+    printf 'Expected not to find: %s\n' "$unexpected" >&2
+    printf 'Actual log:\n' >&2
+    cat "$file" >&2
+    return 1
+  fi
+}
+
+prepare_repo() {
+  local repo="$1"
+
+  mkdir -p "$repo/app"
+  printf '{}\n' > "$repo/app/package.json"
+  printf '{}\n' > "$repo/app/package-lock.json"
+  git -C "$repo" init -q
+}
+
+write_fake_commands() {
+  local bin_dir="$1"
+  local call_log="$2"
+  local node_version="$3"
+
+  mkdir -p "$bin_dir"
+
+  cat > "$bin_dir/node" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  printf '%s\\n' "$node_version"
+  printf 'node --version\\n' >> "$call_log"
+  exit 0
+fi
+printf 'node %s\\n' "\$*" >> "$call_log"
+EOF
+
+  cat > "$bin_dir/npm" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'npm %s\\n' "\$*" >> "$call_log"
+EOF
+
+  cat > "$bin_dir/docker" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "\$*" >> "$call_log"
+EOF
+
+  cat > "$bin_dir/supabase" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'supabase %s\\n' "\$*" >> "$call_log"
+EOF
+
+  chmod +x "$bin_dir/node" "$bin_dir/npm" "$bin_dir/docker" "$bin_dir/supabase"
+}
+
+run_entrypoint() {
+  local repo="$1"
+  local bin_dir="$2"
+  local entrypoint="$3"
+
+  (cd "$repo" && PATH="$bin_dir:$PATH" bash "$script_dir/$entrypoint" >/dev/null)
+}
+
+test_setup_runs_dependencies_in_order() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  write_fake_commands "$bin_dir" "$call_log" "v22.12.0"
+  run_entrypoint "$repo" "$bin_dir" "setup.sh"
+
+  local expected actual
+  expected=$'node --version\nnpm ci --no-audit\nnpm run db:generate'
+  actual="$(cat "$call_log")"
+  [ "$actual" = "$expected" ] || fail "setup call order was unexpected"
+}
+
+test_maintenance_runs_dependencies_in_order() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  write_fake_commands "$bin_dir" "$call_log" "v22.12.0"
+  run_entrypoint "$repo" "$bin_dir" "maintenance.sh"
+
+  local expected actual
+  expected=$'node --version\nnpm ci --no-audit\nnpm run db:generate'
+  actual="$(cat "$call_log")"
+  [ "$actual" = "$expected" ] || fail "maintenance call order was unexpected"
+}
+
+test_rejects_unsupported_node_versions() {
+  local version tmp_dir repo bin_dir call_log
+
+  for version in v20.19.0 v22.11.0; do
+    tmp_dir="$(mktemp -d)"
+    repo="$tmp_dir/repo"
+    bin_dir="$tmp_dir/bin"
+    call_log="$tmp_dir/calls.log"
+    touch "$call_log"
+
+    prepare_repo "$repo"
+    write_fake_commands "$bin_dir" "$call_log" "$version"
+
+    if run_entrypoint "$repo" "$bin_dir" "setup.sh"; then
+      fail "setup accepted unsupported Node.js version $version"
+    fi
+
+    assert_contains "$call_log" "node --version"
+    assert_not_contains "$call_log" "npm "
+  done
+}
+
+test_does_not_start_external_services_or_source_env() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  touch "$call_log"
+
+  prepare_repo "$repo"
+  printf 'command_that_must_not_run\n' > "$repo/app/.env.local"
+  write_fake_commands "$bin_dir" "$call_log" "v22.12.0"
+  run_entrypoint "$repo" "$bin_dir" "setup.sh"
+
+  assert_not_contains "$call_log" "docker "
+  assert_not_contains "$call_log" "supabase "
+  assert_not_contains "$call_log" "command_that_must_not_run"
+}
+
+test_requires_app_package() {
+  local tmp_dir repo bin_dir call_log
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  bin_dir="$tmp_dir/bin"
+  call_log="$tmp_dir/calls.log"
+  mkdir -p "$repo"
+  touch "$call_log"
+  git -C "$repo" init -q
+  write_fake_commands "$bin_dir" "$call_log" "v22.12.0"
+
+  if run_entrypoint "$repo" "$bin_dir" "setup.sh"; then
+    fail "setup succeeded without app/package.json"
+  fi
+
+  assert_not_contains "$call_log" "node --version"
+  assert_not_contains "$call_log" "npm "
+}
+
+test_setup_runs_dependencies_in_order
+test_maintenance_runs_dependencies_in_order
+test_rejects_unsupported_node_versions
+test_does_not_start_external_services_or_source_env
+test_requires_app_package
+
+printf 'cloud scripts tests passed\n'

--- a/.codex/cloud/cloud-scripts.test.sh
+++ b/.codex/cloud/cloud-scripts.test.sh
@@ -45,8 +45,10 @@ write_fake_commands() {
   local bin_dir="$1"
   local call_log="$2"
   local node_version="$3"
+  local cli_call_log="${call_log}.cli"
 
   mkdir -p "$bin_dir"
+  touch "$cli_call_log"
 
   cat > "$bin_dir/node" <<EOF
 #!/usr/bin/env bash
@@ -77,7 +79,25 @@ set -euo pipefail
 printf 'supabase %s\\n' "\$*" >> "$call_log"
 EOF
 
-  chmod +x "$bin_dir/node" "$bin_dir/npm" "$bin_dir/docker" "$bin_dir/supabase"
+  cat > "$bin_dir/ctx7" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'ctx7 %s\\n' "\$*" >> "$cli_call_log"
+if [ "\${1:-}" = "--version" ]; then
+  printf '0.5.7\\n'
+fi
+EOF
+
+  cat > "$bin_dir/vercel" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'vercel %s\\n' "\$*" >> "$cli_call_log"
+if [ "\${1:-}" = "--version" ]; then
+  printf '58.7.1\\n'
+fi
+EOF
+
+  chmod +x "$bin_dir/node" "$bin_dir/npm" "$bin_dir/docker" "$bin_dir/supabase" "$bin_dir/ctx7" "$bin_dir/vercel"
 }
 
 run_entrypoint() {
@@ -104,6 +124,10 @@ test_setup_runs_dependencies_in_order() {
   expected=$'node --version\nnpm ci --no-audit\nnpm run db:generate'
   actual="$(cat "$call_log")"
   [ "$actual" = "$expected" ] || fail "setup call order was unexpected"
+  assert_contains "${call_log}.cli" "ctx7 --version"
+  assert_contains "${call_log}.cli" "vercel --version"
+  assert_not_contains "$call_log" "npm install --global"
+  assert_not_contains "$call_log" "mcpc"
 }
 
 test_maintenance_runs_dependencies_in_order() {
@@ -122,6 +146,10 @@ test_maintenance_runs_dependencies_in_order() {
   expected=$'node --version\nnpm ci --no-audit\nnpm run db:generate'
   actual="$(cat "$call_log")"
   [ "$actual" = "$expected" ] || fail "maintenance call order was unexpected"
+  assert_contains "${call_log}.cli" "ctx7 --version"
+  assert_contains "${call_log}.cli" "vercel --version"
+  assert_not_contains "$call_log" "npm install --global"
+  assert_not_contains "$call_log" "mcpc"
 }
 
 test_rejects_unsupported_node_versions() {

--- a/.codex/cloud/common.sh
+++ b/.codex/cloud/common.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+codex_cloud_log() {
+  printf '[codex-cloud] %s\n' "$*" >&2
+}
+
+codex_cloud_require_node_22() {
+  if ! command -v node >/dev/null 2>&1; then
+    codex_cloud_log "Node.js 22.12+ が見つかりません。Cloud Environment の Node.js を 22 系に設定してください。"
+    return 1
+  fi
+
+  local version major minor
+  version="$(node --version)"
+  if [[ ! "$version" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+    codex_cloud_log "Node.js のバージョンを判定できません: $version"
+    return 1
+  fi
+
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  if [ "$major" != "22" ] || [ "$minor" -lt 12 ]; then
+    codex_cloud_log "Node.js 22.12+ が必要です: $version"
+    return 1
+  fi
+}
+
+codex_cloud_setup_dependencies() {
+  local repo_root="$1"
+  local app_dir="$repo_root/app"
+
+  if [ ! -f "$app_dir/package.json" ]; then
+    codex_cloud_log "app/package.json が見つかりません: $app_dir/package.json"
+    return 1
+  fi
+
+  if [ ! -f "$app_dir/package-lock.json" ]; then
+    codex_cloud_log "app/package-lock.json が見つかりません。npm ci に必要です。"
+    return 1
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    codex_cloud_log "npm が見つかりません。Cloud Environment の Node.js 設定を確認してください。"
+    return 1
+  fi
+
+  codex_cloud_require_node_22
+
+  codex_cloud_log "依存関係をインストールします。"
+  cd "$app_dir"
+  npm ci --no-audit
+
+  codex_cloud_log "Prisma Client を生成します。"
+  npm run db:generate
+  codex_cloud_log "セットアップが完了しました。"
+}

--- a/.codex/cloud/common.sh
+++ b/.codex/cloud/common.sh
@@ -26,6 +26,71 @@ codex_cloud_require_node_22() {
   fi
 }
 
+codex_cloud_cli_version_matches() {
+  local command_name="$1"
+  local actual_version="$2"
+  local expected_version="$3"
+
+  if [ "$actual_version" = "$expected_version" ]; then
+    return 0
+  fi
+
+  case "$command_name:$actual_version" in
+    "ctx7:ctx7 $expected_version" | "vercel:Vercel CLI $expected_version")
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+codex_cloud_setup_pinned_cli() {
+  local command_name="$1"
+  local package_name="$2"
+  local expected_version="$3"
+  local display_name="$4"
+  local installed_version
+
+  if command -v "$command_name" >/dev/null 2>&1; then
+    installed_version="$($command_name --version 2>/dev/null || true)"
+    if codex_cloud_cli_version_matches "$command_name" "$installed_version" "$expected_version"; then
+      codex_cloud_log "$display_name はセットアップ済みです: $command_name $expected_version"
+      return 0
+    fi
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    codex_cloud_log "$display_name の導入に npm が必要です。"
+    return 1
+  fi
+
+  codex_cloud_log "$display_name をインストールします: $package_name@$expected_version"
+  if ! npm install --global --no-audit --no-fund "$package_name@$expected_version"; then
+    codex_cloud_log "$display_name のインストールに失敗しました。"
+    return 1
+  fi
+  hash -r 2>/dev/null || true
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    codex_cloud_log "$display_name のインストール後に $command_name が見つかりません。"
+    return 1
+  fi
+
+  installed_version="$($command_name --version 2>/dev/null || true)"
+  if ! codex_cloud_cli_version_matches "$command_name" "$installed_version" "$expected_version"; then
+    codex_cloud_log "$display_name のバージョンが一致しません: expected=$expected_version actual=${installed_version:-unknown}"
+    return 1
+  fi
+}
+
+codex_cloud_setup_context7_cli() {
+  codex_cloud_setup_pinned_cli "ctx7" "ctx7" "0.5.7" "Context7 CLI"
+}
+
+codex_cloud_setup_vercel_cli() {
+  codex_cloud_setup_pinned_cli "vercel" "vercel" "58.7.1" "Vercel CLI"
+}
+
 codex_cloud_setup_dependencies() {
   local repo_root="$1"
   local app_dir="$repo_root/app"
@@ -46,6 +111,8 @@ codex_cloud_setup_dependencies() {
   fi
 
   codex_cloud_require_node_22
+  codex_cloud_setup_context7_cli
+  codex_cloud_setup_vercel_cli
 
   codex_cloud_log "依存関係をインストールします。"
   cd "$app_dir"

--- a/.codex/cloud/common.test.sh
+++ b/.codex/cloud/common.test.sh
@@ -38,11 +38,16 @@ esac
 EOF
 chmod +x "$fake_bin/npm"
 
+codex_cloud_test_prepare_path() {
+  PATH="$fake_bin:/usr/bin:/bin"
+  export PATH
+}
+
 export CODEX_CLOUD_TEST_NPM_LOG="$test_tmp/npm.log"
 export CODEX_CLOUD_TEST_BIN="$fake_bin"
 export CODEX_CLOUD_TEST_CTX7_VERSION='0.5.7'
 export CODEX_CLOUD_TEST_VERCEL_VERSION='58.7.1'
-PATH="$fake_bin:$PATH"
+codex_cloud_test_prepare_path
 
 codex_cloud_setup_context7_cli
 
@@ -93,13 +98,14 @@ assert_no_mcpc_install
 write_existing_cli() {
   local command_name="$1"
   local version="$2"
-  cat >"$fake_bin/$command_name" <<EOF
+  local destination_bin="${3:-$fake_bin}"
+  cat >"$destination_bin/$command_name" <<EOF
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
   printf '%s\\n' '$version'
 fi
 EOF
-  chmod +x "$fake_bin/$command_name"
+  chmod +x "$destination_bin/$command_name"
 }
 
 test_reinstalls_mismatched_versions() {
@@ -148,5 +154,37 @@ test_rejects_wrong_post_install_version() {
 
 test_reinstalls_mismatched_versions
 test_rejects_wrong_post_install_version
+
+test_missing_cli_is_not_satisfied_by_host_cli() {
+  local host_cli_bin="$test_tmp/host-cli-bin"
+  mkdir -p "$host_cli_bin"
+
+  write_existing_cli ctx7 '0.5.7' "$host_cli_bin"
+  write_existing_cli vercel '58.7.1' "$host_cli_bin"
+
+  rm -f "$fake_bin/ctx7" "$fake_bin/vercel"
+  export CODEX_CLOUD_TEST_CTX7_VERSION='0.5.7'
+  export CODEX_CLOUD_TEST_VERCEL_VERSION='58.7.1'
+  : >"$CODEX_CLOUD_TEST_NPM_LOG"
+
+  (
+    PATH="$host_cli_bin:$PATH"
+    export PATH
+    [ "$(command -v ctx7)" = "$host_cli_bin/ctx7" ]
+    [ "$(command -v vercel)" = "$host_cli_bin/vercel" ]
+    codex_cloud_test_prepare_path
+    codex_cloud_setup_context7_cli
+    codex_cloud_setup_vercel_cli
+  )
+
+  expected=$'install --global --no-audit --no-fund ctx7@0.5.7\ninstall --global --no-audit --no-fund vercel@58.7.1'
+  actual="$(cat "$CODEX_CLOUD_TEST_NPM_LOG")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'host CLI shadowed the missing fake CLI case\nexpected: %s\nactual:   %s\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+test_missing_cli_is_not_satisfied_by_host_cli
 
 printf 'ok: Codex Cloud installs pinned Context7 and Vercel CLIs without mcpc\n'

--- a/.codex/cloud/common.test.sh
+++ b/.codex/cloud/common.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# shellcheck disable=SC1091
+. "$script_dir/common.sh"
+
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/npm" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CODEX_CLOUD_TEST_NPM_LOG"
+case "$*" in
+  *"ctx7@0.5.7"*)
+    cat >"$CODEX_CLOUD_TEST_BIN/ctx7" <<'CTX7'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' "${CODEX_CLOUD_TEST_CTX7_VERSION:?}"
+fi
+CTX7
+    chmod +x "$CODEX_CLOUD_TEST_BIN/ctx7"
+    ;;
+  *"vercel@58.7.1"*)
+    cat >"$CODEX_CLOUD_TEST_BIN/vercel" <<'VERCEL'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' "${CODEX_CLOUD_TEST_VERCEL_VERSION:?}"
+fi
+VERCEL
+    chmod +x "$CODEX_CLOUD_TEST_BIN/vercel"
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/npm"
+
+export CODEX_CLOUD_TEST_NPM_LOG="$test_tmp/npm.log"
+export CODEX_CLOUD_TEST_BIN="$fake_bin"
+export CODEX_CLOUD_TEST_CTX7_VERSION='0.5.7'
+export CODEX_CLOUD_TEST_VERCEL_VERSION='58.7.1'
+PATH="$fake_bin:$PATH"
+
+codex_cloud_setup_context7_cli
+
+expected='install --global --no-audit --no-fund ctx7@0.5.7'
+actual="$(cat "$CODEX_CLOUD_TEST_NPM_LOG")"
+
+if [ "$actual" != "$expected" ]; then
+  printf 'unexpected npm invocation\nexpected: %s\nactual:   %s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+: >"$CODEX_CLOUD_TEST_NPM_LOG"
+codex_cloud_setup_context7_cli
+
+if [ -s "$CODEX_CLOUD_TEST_NPM_LOG" ]; then
+  printf 'ctx7 is already current but npm was invoked again\n' >&2
+  exit 1
+fi
+
+: >"$CODEX_CLOUD_TEST_NPM_LOG"
+codex_cloud_setup_vercel_cli
+
+expected='install --global --no-audit --no-fund vercel@58.7.1'
+actual="$(cat "$CODEX_CLOUD_TEST_NPM_LOG")"
+
+if [ "$actual" != "$expected" ]; then
+  printf 'unexpected npm invocation\nexpected: %s\nactual:   %s\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+: >"$CODEX_CLOUD_TEST_NPM_LOG"
+codex_cloud_setup_vercel_cli
+
+if [ -s "$CODEX_CLOUD_TEST_NPM_LOG" ]; then
+  printf 'vercel is already current but npm was invoked again\n' >&2
+  exit 1
+fi
+
+assert_no_mcpc_install() {
+  if grep -Fq 'mcpc' "$CODEX_CLOUD_TEST_NPM_LOG"; then
+    printf 'mcpc installation was requested by the Cloud CLI setup\n' >&2
+    exit 1
+  fi
+}
+
+assert_no_mcpc_install
+
+write_existing_cli() {
+  local command_name="$1"
+  local version="$2"
+  cat >"$fake_bin/$command_name" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  printf '%s\\n' '$version'
+fi
+EOF
+  chmod +x "$fake_bin/$command_name"
+}
+
+test_reinstalls_mismatched_versions() {
+  write_existing_cli ctx7 '0.5.6'
+  write_existing_cli vercel '58.7.0'
+  : >"$CODEX_CLOUD_TEST_NPM_LOG"
+
+  codex_cloud_setup_context7_cli
+  codex_cloud_setup_vercel_cli
+
+  expected=$'install --global --no-audit --no-fund ctx7@0.5.7\ninstall --global --no-audit --no-fund vercel@58.7.1'
+  actual="$(cat "$CODEX_CLOUD_TEST_NPM_LOG")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'mismatched CLIs were not reinstalled\nexpected: %s\nactual:   %s\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+
+  [ "$(ctx7 --version)" = '0.5.7' ] || exit 1
+  [ "$(vercel --version)" = '58.7.1' ] || exit 1
+  assert_no_mcpc_install
+}
+
+test_rejects_wrong_post_install_version() {
+  rm -f "$fake_bin/ctx7" "$fake_bin/vercel"
+  export CODEX_CLOUD_TEST_CTX7_VERSION='0.5.6'
+  export CODEX_CLOUD_TEST_VERCEL_VERSION='58.7.0'
+  : >"$CODEX_CLOUD_TEST_NPM_LOG"
+
+  if codex_cloud_setup_context7_cli; then
+    printf 'ctx7 accepted an incorrect post-install version\n' >&2
+    exit 1
+  fi
+  if codex_cloud_setup_vercel_cli; then
+    printf 'vercel accepted an incorrect post-install version\n' >&2
+    exit 1
+  fi
+
+  expected=$'install --global --no-audit --no-fund ctx7@0.5.7\ninstall --global --no-audit --no-fund vercel@58.7.1'
+  actual="$(cat "$CODEX_CLOUD_TEST_NPM_LOG")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'wrong post-install versions did not fail as expected\nexpected: %s\nactual:   %s\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+  assert_no_mcpc_install
+}
+
+test_reinstalls_mismatched_versions
+test_rejects_wrong_post_install_version
+
+printf 'ok: Codex Cloud installs pinned Context7 and Vercel CLIs without mcpc\n'

--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -9,6 +9,6 @@ if [ -z "$repo_root" ]; then
   exit 1
 fi
 
-# shellcheck source=common.sh
+# shellcheck disable=SC1091
 . "$script_dir/common.sh"
 codex_cloud_setup_dependencies "$repo_root"

--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+if [ -z "$repo_root" ]; then
+  printf '[codex-cloud] Git repository root を解決できません。\n' >&2
+  exit 1
+fi
+
+# shellcheck source=common.sh
+. "$script_dir/common.sh"
+codex_cloud_setup_dependencies "$repo_root"

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -9,6 +9,6 @@ if [ -z "$repo_root" ]; then
   exit 1
 fi
 
-# shellcheck source=common.sh
+# shellcheck disable=SC1091
 . "$script_dir/common.sh"
 codex_cloud_setup_dependencies "$repo_root"

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+if [ -z "$repo_root" ]; then
+  printf '[codex-cloud] Git repository root を解決できません。\n' >&2
+  exit 1
+fi
+
+# shellcheck source=common.sh
+. "$script_dir/common.sh"
+codex_cloud_setup_dependencies "$repo_root"

--- a/.github/scripts/prepare-e2e-env.sh
+++ b/.github/scripts/prepare-e2e-env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+status_file="${1:-}"
+
+if [ -z "$repo_root" ]; then
+  printf '[e2e-env] Git repository root を解決できません。\n' >&2
+  exit 1
+fi
+
+if [ -z "$status_file" ] || [ ! -f "$status_file" ]; then
+  printf '[e2e-env] Supabase status file が見つかりません。\n' >&2
+  exit 1
+fi
+
+app_dir="$repo_root/app"
+if [ ! -d "$app_dir" ]; then
+  printf '[e2e-env] app ディレクトリが見つかりません: %s\n' "$app_dir" >&2
+  exit 1
+fi
+
+# `supabase status -o env` は Supabase CLI 自身が生成した shell assignment のみを読む。
+set -a
+# shellcheck disable=SC1090
+. "$status_file"
+set +a
+
+: "${API_URL:?Supabase API_URL is missing}"
+: "${ANON_KEY:?Supabase ANON_KEY is missing}"
+: "${SERVICE_ROLE_KEY:?Supabase SERVICE_ROLE_KEY is missing}"
+: "${DB_URL:?Supabase DB_URL is missing}"
+
+umask 077
+tmp_env="$(mktemp "${TMPDIR:-/tmp}/volunty-e2e-env.XXXXXX")"
+trap 'rm -f "$tmp_env"' EXIT
+
+printf '%s\n' \
+  "NEXT_PUBLIC_SUPABASE_URL=$API_URL" \
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY" \
+  "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY" \
+  "DATABASE_URL=$DB_URL" \
+  "DIRECT_URL=$DB_URL" \
+  'E2E_AUTH_ENABLED=true' \
+  'E2E_TEST_USER_PASSWORD=volunty-e2e-password' \
+  > "$tmp_env"
+
+mv "$tmp_env" "$app_dir/.env.local"
+printf '[e2e-env] app/.env.local を生成しました。\n'

--- a/.github/scripts/prepare-e2e-env.test.sh
+++ b/.github/scripts/prepare-e2e-env.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fqx "$expected" "$file" || {
+    printf 'Expected to find line: %s\n' "$expected" >&2
+    printf 'Actual content:\n' >&2
+    cat "$file" >&2
+    return 1
+  }
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq "$unexpected" "$file"; then
+    printf 'Expected not to find: %s\n' "$unexpected" >&2
+    printf 'Actual content:\n' >&2
+    cat "$file" >&2
+    return 1
+  fi
+}
+
+prepare_repo() {
+  local repo="$1"
+
+  mkdir -p "$repo/app"
+  git -C "$repo" init -q
+}
+
+write_status_env() {
+  local status_file="$1"
+
+  cat > "$status_file" <<'EOF'
+API_URL="http://127.0.0.1:54321"
+ANON_KEY="local-anon-key"
+SERVICE_ROLE_KEY="local-service-role-key"
+DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+EOF
+}
+
+run_helper() {
+  local repo="$1"
+  local status_file="$2"
+  local stdout_file="$3"
+  local stderr_file="$4"
+
+  (cd "$repo" && bash "$script_dir/prepare-e2e-env.sh" "$status_file" >"$stdout_file" 2>"$stderr_file")
+}
+
+test_generates_local_e2e_environment_without_logging_secrets() {
+  local tmp_dir repo status_file stdout_file stderr_file env_file
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  status_file="$tmp_dir/supabase.env"
+  stdout_file="$tmp_dir/stdout.log"
+  stderr_file="$tmp_dir/stderr.log"
+  env_file="$repo/app/.env.local"
+
+  prepare_repo "$repo"
+  write_status_env "$status_file"
+  run_helper "$repo" "$status_file" "$stdout_file" "$stderr_file"
+
+  assert_contains "$env_file" "NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321"
+  assert_contains "$env_file" "NEXT_PUBLIC_SUPABASE_ANON_KEY=local-anon-key"
+  assert_contains "$env_file" "SUPABASE_SERVICE_ROLE_KEY=local-service-role-key"
+  assert_contains "$env_file" "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+  assert_contains "$env_file" "DIRECT_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+  assert_contains "$env_file" "E2E_AUTH_ENABLED=true"
+  assert_contains "$env_file" "E2E_TEST_USER_PASSWORD=volunty-e2e-password"
+  assert_not_contains "$stdout_file" "local-service-role-key"
+  assert_not_contains "$stderr_file" "local-service-role-key"
+}
+
+test_requires_status_file() {
+  local tmp_dir repo stdout_file stderr_file
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  stdout_file="$tmp_dir/stdout.log"
+  stderr_file="$tmp_dir/stderr.log"
+
+  prepare_repo "$repo"
+  if run_helper "$repo" "$tmp_dir/missing.env" "$stdout_file" "$stderr_file"; then
+    fail "helper succeeded without a Supabase status file"
+  fi
+
+  [ ! -f "$repo/app/.env.local" ] || fail "helper created env file without status input"
+}
+
+test_requires_supabase_values() {
+  local tmp_dir repo status_file stdout_file stderr_file
+  tmp_dir="$(mktemp -d)"
+  repo="$tmp_dir/repo"
+  status_file="$tmp_dir/supabase.env"
+  stdout_file="$tmp_dir/stdout.log"
+  stderr_file="$tmp_dir/stderr.log"
+
+  prepare_repo "$repo"
+  printf 'API_URL="http://127.0.0.1:54321"\n' > "$status_file"
+  if run_helper "$repo" "$status_file" "$stdout_file" "$stderr_file"; then
+    fail "helper succeeded without required Supabase values"
+  fi
+
+  [ ! -f "$repo/app/.env.local" ] || fail "helper created partial env file"
+}
+
+test_generates_local_e2e_environment_without_logging_secrets
+test_requires_status_file
+test_requires_supabase_values
+
+printf 'E2E environment helper tests passed\n'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm test
 
       - name: Run production build
-        run: npm run build
+        run: npm run build -- --webpack
 
   e2e:
     name: e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit
+
+      - name: Generate Prisma Client
+        run: npm run db:generate
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run production build
+        run: npm run build
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v2
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci --no-audit
+
+      - name: Install Playwright Chromium
+        working-directory: app
+        run: npx playwright install --with-deps chromium
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Export local Supabase status
+        run: supabase status -o env > "$RUNNER_TEMP/supabase.env"
+
+      - name: Prepare E2E environment
+        run: bash .github/scripts/prepare-e2e-env.sh "$RUNNER_TEMP/supabase.env"
+
+      - name: Apply local migrations
+        run: supabase migration up --local
+
+      - name: Run Playwright E2E
+        working-directory: app
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: |
+            app/playwright-report
+            app/test-results
+          if-no-files-found: ignore
+
+      - name: Stop local Supabase
+        if: ${{ always() }}
+        run: supabase stop --no-backup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Prepare E2E environment
         run: bash .github/scripts/prepare-e2e-env.sh "$RUNNER_TEMP/supabase.env"
 
-      - name: Apply local migrations
-        run: supabase migration up --local
+      - name: Reset local database and seed
+        run: supabase db reset --local
 
       - name: Run Playwright E2E
         working-directory: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
   quality:
     name: quality
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:1
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder
+      SUPABASE_SERVICE_ROLE_KEY: ci-placeholder
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:1/postgres
+      DIRECT_URL: postgresql://postgres:postgres@127.0.0.1:1/postgres
     defaults:
       run:
         working-directory: app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TZ: Asia/Tokyo
+
 concurrency:
   group: pull-request-ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -1125,10 +1125,12 @@ export async function updateApplicationStatus(
         : newStatus === "rejected"
           ? "declined"
           : "completed";
+    const now = new Date().toISOString();
+
     // ステータスを更新
     const { error: updateError } = await supabase
       .from("t_matching_candidate")
-      .update({ status: dbStatus })
+      .update({ status: dbStatus, status_changed_at: now, updated_at: now })
       .eq("id", applicationId);
 
     if (updateError) {

--- a/app/src/lib/dashboard/actions.ts
+++ b/app/src/lib/dashboard/actions.ts
@@ -1125,12 +1125,10 @@ export async function updateApplicationStatus(
         : newStatus === "rejected"
           ? "declined"
           : "completed";
-    const now = new Date().toISOString();
-
     // ステータスを更新
     const { error: updateError } = await supabase
       .from("t_matching_candidate")
-      .update({ status: dbStatus, status_changed_at: now, updated_at: now })
+      .update({ status: dbStatus })
       .eq("id", applicationId);
 
     if (updateError) {

--- a/app/src/lib/dashboard/applicants.test.ts
+++ b/app/src/lib/dashboard/applicants.test.ts
@@ -654,13 +654,7 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "approved");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "accepted",
-        status_changed_at: expect.any(String),
-        updated_at: expect.any(String),
-      })
-    ); // UI: approved → DB: accepted
+    expect(mockUpdate).toHaveBeenCalledWith({ status: "accepted" }); // UI: approved → DB: accepted
     expect(mockFrom).toHaveBeenCalledWith("t_matching_candidate");
   });
 
@@ -682,13 +676,7 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "rejected");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "declined",
-        status_changed_at: expect.any(String),
-        updated_at: expect.any(String),
-      })
-    ); // UI: rejected → DB: declined
+    expect(mockUpdate).toHaveBeenCalledWith({ status: "declined" }); // UI: rejected → DB: declined
   });
 
   it("承認済み応募を活動完了に更新できる", async () => {
@@ -709,13 +697,7 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "completed");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "completed",
-        status_changed_at: expect.any(String),
-        updated_at: expect.any(String),
-      })
-    );
+    expect(mockUpdate).toHaveBeenCalledWith({ status: "completed" });
   });
 
   it("承認済み以外の応募は活動完了に更新できない", async () => {

--- a/app/src/lib/dashboard/applicants.test.ts
+++ b/app/src/lib/dashboard/applicants.test.ts
@@ -654,7 +654,11 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "approved");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "accepted" }); // UI: approved → DB: accepted
+    expect(mockUpdate).toHaveBeenCalledWith({
+      status: "accepted",
+      status_changed_at: expect.any(String),
+      updated_at: expect.any(String),
+    }); // UI: approved → DB: accepted
     expect(mockFrom).toHaveBeenCalledWith("t_matching_candidate");
   });
 
@@ -676,7 +680,11 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "rejected");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "declined" }); // UI: rejected → DB: declined
+    expect(mockUpdate).toHaveBeenCalledWith({
+      status: "declined",
+      status_changed_at: expect.any(String),
+      updated_at: expect.any(String),
+    }); // UI: rejected → DB: declined
   });
 
   it("承認済み応募を活動完了に更新できる", async () => {
@@ -697,7 +705,11 @@ describe("updateApplicationStatus", () => {
       await updateApplicationStatus("app-1", "completed");
 
     expect(result.success).toBe(true);
-    expect(mockUpdate).toHaveBeenCalledWith({ status: "completed" });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      status: "completed",
+      status_changed_at: expect.any(String),
+      updated_at: expect.any(String),
+    });
   });
 
   it("承認済み以外の応募は活動完了に更新できない", async () => {

--- a/docs/branch-workflow.md
+++ b/docs/branch-workflow.md
@@ -4,59 +4,58 @@
 
 ## ブランチ構成
 
-| ブランチ    | 用途                                     | Vercelデプロイ先       |
-| ----------- | ---------------------------------------- | ---------------------- |
-| `main`      | 本番運用専用。直接pushは禁止             | **Production**         |
-| `preview`   | プレビュー確認用。安定したらmainにマージ | **Preview**            |
-| `develop`   | 開発用。必要に応じてpreviewに統合        | なし（デプロイしない） |
-| `feature/*` | 機能開発用。PRでpreviewかmainに向ける    | なし（デプロイしない） |
+| ブランチ | 用途 | Vercelデプロイ先 |
+| --- | --- | --- |
+| `main` | 本番運用専用。直接pushは禁止 | **Production** |
+| `preview` | 既存のプレビュー確認用。標準フローの必須中継地点ではない | **Preview** |
+| `develop` | 既存の開発用ブランチ | **Preview** |
+| `feature/*` / `codex/*` | 機能開発用。`main` 向けPRを作成 | **Preview** |
 
 ## 日常のワークフロー
 
 ### 機能開発〜プレビュー確認
 
 ```bash
-# 1. developまたはfeature/* ブランチで作業
-git checkout develop
-git checkout -b feature/my-feature   # 任意
+# 1. mainからcodex/*またはfeature/*ブランチを作成
+git checkout main
+git checkout -b codex/my-feature   # 任意
 
 # 2. コードを変更してcommit
 git add .
 git commit -m "feat: ○○機能を追加"
 
 # 3. GitHubにpush → Vercelが自動でPreviewデプロイ
-git push origin feature/my-feature
+git push origin codex/my-feature
 
-# 4. GitHub上でPRを作成 → PRにVercelプレビューURLが自動コメントされる
+# 4. main向けPRを作成 → PRにVercelプレビューURLが表示される
 # 5. スマホブラウザでプレビューURLを開いてUIを確認
+# 6. GitHub ActionsとCodex Reviewの結果を確認
 ```
 
-### プレビュー確認OKのとき
+### mainへマージするとき
 
 ```bash
-# feature/* → preview → main の順でマージ
-# ① feature/* → preview にマージ（GitHub上でPR）
-# ② preview → main にマージ（GitHub上でPR） → Productionにデプロイ
+# codex/*またはfeature/* → main にマージ（GitHub上でPR）
+# mainへのマージは人間が行う → Productionにデプロイ
 ```
 
-### スマホからAI（Claude Code Web）で開発する場合
+### Codex Cloudで開発する場合
 
-1. [claude.ai/code](https://claude.ai/code) でリポジトリに接続
-2. プロンプトで指示（例:「○○画面を実装して、previewブランチにPRを作成して」）
-3. Claude Codeが自動でコードを書いてPRを作成
-4. VercelがPRを検知してプレビューデプロイ → URLが発行される
-5. スマホブラウザでUIを確認
-6. OKならGitHub上でPRをマージ
+1. Codex Cloudでリポジトリ `seikatu-gakari/volunty` と `main` を選択
+2. 設計案と実装計画を承認しながら実装を進める
+3. Codex Cloudが `codex/*` ブランチへpushし、main向けPRを作成
+4. Vercelがブランチpushを検知してプレビューデプロイ → URLが発行される
+5. スマホブラウザでPreview URLを開いてUIを確認
+6. GitHub ActionsとCodex Reviewが成功したら、人間がmainへマージ
 
 ## Vercelデプロイのトリガー
 
-`main` と `preview` ブランチのpushのみデプロイされます。それ以外はスキップ。
+現在のVercel設定では、`main` はProduction、それ以外のブランチpushはPreviewとしてデプロイされます。
 
-| イベント                       | デプロイ先                   |
-| ------------------------------ | ---------------------------- |
-| `main` へのpush/マージ         | Production                   |
-| `preview` へのpush             | Preview                      |
-| `develop` / `feature/*` のpush | **スキップ（デプロイなし）** |
+| イベント | デプロイ先 |
+| --- | --- |
+| `main` へのpush/マージ | Production |
+| `preview` / `develop` / `feature/*` / `codex/*` のpush | Preview |
 
 ## 本番DBマイグレーション
 
@@ -82,15 +81,9 @@ GitHub の `Repository` → `Settings` → `Secrets and variables` → `Actions`
 
 失敗時は GitHub の `Actions` → `Production DB Migration` でログを確認し、Secret や接続先を修正してから `Run workflow` で再実行します。
 
-### ブランチ制限の設定（初回のみ・Vercelダッシュボード）
+### Vercel設定の確認
 
-Vercel → プロジェクト → **Settings → Git → Ignored Build Step** に以下を入力して保存：
-
-```bash
-if [ "$VERCEL_GIT_COMMIT_REF" = "main" ] || [ "$VERCEL_GIT_COMMIT_REF" = "preview" ]; then exit 1; else exit 0; fi
-```
-
-> `exit 0` = ビルドをスキップ、`exit 1` = ビルドを実行（Vercelの仕様）
+Vercel → プロジェクト → **Settings → Git** で、feature/codexブランチのpushがPreviewデプロイ対象になっていることを確認する。main/preview以外をスキップするIgnored Build Stepは使用しない。
 
 ## 注意事項
 

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -51,7 +51,7 @@ E2EはGitHub Actions上の一時Supabaseを使う。E2E用のservice role keyは
 `.github/workflows/ci.yml` は `main` 向けPull Requestで次を実行する。
 
 - `quality`: npm install、Prisma生成、lint、UT、`npm run build -- --webpack`
-- `e2e`: Supabase CLIでlocal環境を起動、migration適用、Playwright E2E、結果artifact保存、Supabase停止
+- `e2e`: Supabase CLIでlocal環境を起動、DB reset（migration + seed）、Playwright E2E、結果artifact保存、Supabase停止
 
 `quality` のbuildは実サービスへ接続しないplaceholder環境変数をjob限定で使う。`e2e` はSupabase CLIが発行する一時環境変数を `.env.local` に設定する。
 

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -49,7 +49,7 @@ E2EはGitHub Actions上の一時Supabaseを使う。E2E用のservice role keyは
 
 `.github/workflows/ci.yml` は `main` 向けPull Requestで次を実行する。
 
-- `quality`: npm install、Prisma生成、lint、UT、Next.js build
+- `quality`: npm install、Prisma生成、lint、UT、`npm run build -- --webpack`
 - `e2e`: Supabase CLIでlocal環境を起動、migration適用、Playwright E2E、結果artifact保存、Supabase停止
 
 `quality` と `e2e` を `main` のrequired checksに登録する。

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -25,6 +25,7 @@ Codex設定画面で `seikatu-gakari/volunty` 用Environmentを作成し、次�
 | Runtime | Node.js 22（22.12以上） |
 | Setup | `bash .codex/cloud/setup.sh` |
 | Maintenance | `bash .codex/cloud/maintenance.sh` |
+| `TZ` | `Asia/Tokyo`（`datetime-local` の解釈をCIと揃える） |
 | Agent internet access | 原則off。必要時だけ信頼できる依存関係ドメインのGET/HEAD/OPTIONS |
 
 Setupは `npm ci --no-audit` と `npm run db:generate`だけを実行する。Docker、Supabase local、開発サーバー、本番migrationは起動しない。

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -28,7 +28,39 @@ Codex設定画面で `seikatu-gakari/volunty` 用Environmentを作成し、次�
 | `TZ` | `Asia/Tokyo`（`datetime-local` の解釈をCIと揃える） |
 | Agent internet access | 原則off。必要時だけ信頼できる依存関係ドメインのGET/HEAD/OPTIONS |
 
-Setupは `npm ci --no-audit` と `npm run db:generate`だけを実行する。Docker、Supabase local、開発サーバー、本番migrationは起動しない。
+SetupとMaintenanceは固定バージョンのContext7 CLIとVercel CLIの導入、`npm ci --no-audit`、`npm run db:generate`だけを実行する。Docker、Supabase local、開発サーバー、本番migrationは起動しない。
+
+### CLI優先のツール構成
+
+ローカル環境では `.codex/config.toml` のネイティブMCP設定を維持する。Codex Cloudでは `mcpc` やネイティブMCPへ依存せず、次のCLIを直接使用する。
+
+| 用途 | Codex Cloudで使用するCLI・方法 |
+| --- | --- |
+| ドキュメント検索 | `ctx7 library` / `ctx7 docs` |
+| ブラウザ・E2E | `cd app && npx playwright` |
+| DB・Prisma | `cd app && npx prisma` |
+| UT | `cd app && npx vitest` |
+| lint | `cd app && npx eslint` |
+| 型チェック | `cd app && npx tsc` |
+| Vercel | `vercel` CLI |
+| コード検索 | `rg` / `git grep` |
+| GitHub操作・PR作成 | Codex Cloud標準のGitHub接続 |
+| Previewデプロイ | featureブランチへのpush |
+
+Context7はsetup/maintenanceで公式 `ctx7@0.5.7` CLIを導入する。Vercel CLIは `vercel@58.7.1` に固定する。
+
+```bash
+ctx7 library next.js 'App Routerのキャッシュ仕様'
+ctx7 docs /vercel/next.js 'App Routerのキャッシュ仕様'
+```
+
+Serena相当のコード調査は `rg`、`git grep`、TypeScript、既存テストで行う。Figma LocalはCloudコンテナから利用できないため使用しない。Context7を使う場合は、Agent internet accessで `context7.com` へのGET/HEAD/OPTIONSだけを許可する。
+
+### Vercel CLI
+
+SetupとMaintenanceは `vercel@58.7.1` を導入し、`vercel --version` でインストール結果を検証する。
+
+Vercel tokenや本番資格情報はCloudへ登録しないため、`vercel deploy`、`vercel env`、`vercel logs`などのアカウント認証を必要とする操作は行わない。Previewデプロイは従来どおりfeatureブランチへのpushで自動実行する。`.vercel/` はローカル生成物として追跡しない。
 
 ### 環境変数とSecret
 

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -1,0 +1,106 @@
+# Volunty Codex Cloud 運用手順
+
+## 標準フロー
+
+Codex Cloud は設計、実装、検証、Pull Request 作成までを担当する。`main` へのマージは人間が行う。
+
+1. Codex Cloudで `seikatu-gakari/volunty` と `main` を対象にタスクを開始する。
+2. Codexが関連コードと設計書を調査し、設計案を提示する。
+3. 人間が設計案を承認する。
+4. Codexが実装計画を提示する。
+5. 人間が実装計画を承認する。
+6. Codexが `codex/<topic>` ブランチで実装し、lint、UT、buildを実行する。
+7. ブランチpushでVercel Previewが自動デプロイされる。
+8. Codexが `main` 向けPull Requestを作成する。
+9. GitHub Actionsのquality/e2e、Codex Review、Vercel Previewを確認する。
+10. 失敗があればCodexに同じPRブランチの修正を依頼する。
+11. 全チェック成功後、人間が `main` にマージする。
+
+## Codex Cloud Environment
+
+Codex設定画面で `seikatu-gakari/volunty` 用Environmentを作成し、次を登録する。
+
+| 項目 | 設定 |
+| --- | --- |
+| Runtime | Node.js 22（22.12以上） |
+| Setup | `bash .codex/cloud/setup.sh` |
+| Maintenance | `bash .codex/cloud/maintenance.sh` |
+| Agent internet access | 原則off。必要時だけ信頼できる依存関係ドメインのGET/HEAD/OPTIONS |
+
+Setupは `npm ci --no-audit` と `npm run db:generate`だけを実行する。Docker、Supabase local、開発サーバー、本番migrationは起動しない。
+
+### 環境変数とSecret
+
+Cloudへ登録するのは、アプリのビルドや静的な検証に必要な非秘密値だけとする。
+
+次の値はCloudへ登録しない。
+
+- 本番 `DATABASE_URL`、`DIRECT_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- Google OAuth secret
+- Vercel token
+- 本番・Preview環境の管理用token
+
+E2EはGitHub Actions上の一時Supabaseを使う。E2E用のservice role keyはActions runner内でSupabase CLIから取得し、ジョブ終了時に破棄する。
+
+## GitHub設定
+
+### Pull Request CI
+
+`.github/workflows/ci.yml` は `main` 向けPull Requestで次を実行する。
+
+- `quality`: npm install、Prisma生成、lint、UT、Next.js build
+- `e2e`: Supabase CLIでlocal環境を起動、migration適用、Playwright E2E、結果artifact保存、Supabase停止
+
+`quality` と `e2e` を `main` のrequired checksに登録する。
+
+### main branch protection
+
+GitHubの `Settings → Branches` で `main` に次を設定する。
+
+- Pull Request経由の変更を必須にする
+- `quality` と `e2e` をrequired checksにする
+- 必須reviewを設定する
+- 未解決reviewがある場合はマージ不可にする
+- force pushとbranch deletionを禁止する
+- 自動マージを有効にしない
+
+Codex Cloudには `main` への直接push・マージ権限を与えない。
+
+### Codex Code Review
+
+Codex設定で対象リポジトリのCode ReviewとAutomatic reviewsを有効にする。レビューはCIや人間の承認の代替ではないため、重大な指摘、CI結果、Previewをすべて確認する。
+
+## Vercel Preview
+
+現在のVercel設定では、`main` はProduction、それ以外のブランチpushはPreviewデプロイになる。
+
+Codex Cloudのブランチpush後、PR画面またはVercel dashboardからPreview URLを確認する。VercelのIgnored Build Stepで `codex/*` を除外しない。
+
+## Cloudへの依頼テンプレート
+
+```text
+Issue #123を対応してください。
+まず関連コードと設計書を調査し、設計案を提示してください。
+設計承認までは実装しないでください。
+設計承認後に実装計画を提示し、計画承認後に実装してください。
+作業ブランチは codex/cloud-setup とし、必要なUT/E2Eを追加・実行してください。
+lint、UT、build、E2E、Vercel Preview、Codex Reviewを確認したうえでmain向けPRを作成してください。
+mainへのマージは行わないでください。
+```
+
+## 失敗時の対応
+
+- Setup失敗: Node.jsが22.12以上か、`app/package-lock.json`が存在するかを確認し、必要ならCloud EnvironmentのcacheをResetする。
+- Quality失敗: Cloudの同じタスクで修正し、lint、UT、buildを再実行する。
+- E2E失敗: GitHub ActionsのPlaywright artifact、trace、screenshotを確認し、同じPRブランチへ修正を依頼する。
+- Preview失敗: Vercelのbuild logと環境変数設定を確認する。本番値をCloudへコピーしない。
+- PR作成失敗: GitHub接続、repository write権限、main branch protectionを確認する。mainの保護を解除して回避しない。
+
+## 関連ファイル
+
+- [Codex Cloud setup](../.codex/cloud/setup.sh)
+- [Codex Cloud maintenance](../.codex/cloud/maintenance.sh)
+- [Pull Request CI](../.github/workflows/ci.yml)
+- [ブランチ運用](branch-workflow.md)
+- [Codex Cloud設計書](superpowers/specs/2026-08-01-codex-cloud-development-design.md)

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -53,6 +53,8 @@ E2EはGitHub Actions上の一時Supabaseを使う。E2E用のservice role keyは
 - `quality`: npm install、Prisma生成、lint、UT、`npm run build -- --webpack`
 - `e2e`: Supabase CLIでlocal環境を起動、migration適用、Playwright E2E、結果artifact保存、Supabase停止
 
+`quality` のbuildは実サービスへ接続しないplaceholder環境変数をjob限定で使う。`e2e` はSupabase CLIが発行する一時環境変数を `.env.local` に設定する。
+
 `quality` と `e2e` を `main` のrequired checksに登録する。
 
 ### main branch protection

--- a/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
+++ b/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
@@ -209,7 +209,7 @@
     working-directory: app
   - run: npm test
     working-directory: app
-  - run: npm run build
+  - run: npm run build -- --webpack
     working-directory: app
   ```
 
@@ -351,7 +351,7 @@
   bash -n .github/scripts/prepare-e2e-env.sh
   cd app && npm run lint
   cd app && npm test
-  cd app && npm run build
+  cd app && npm run build -- --webpack
   ```
 
 - [ ] **Step 5: E2Eを実行する**

--- a/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
+++ b/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
@@ -226,7 +226,7 @@
   - run: supabase start
   - run: supabase status -o env > "$RUNNER_TEMP/supabase.env"
   - run: bash .github/scripts/prepare-e2e-env.sh "$RUNNER_TEMP/supabase.env"
-  - run: supabase migration up --local
+  - run: supabase db reset --local
   - run: npm run test:e2e
     working-directory: app
   ```

--- a/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
+++ b/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
@@ -218,7 +218,7 @@
   E2E job は Node/npm、Supabase CLI、依存関係、Chromiumを準備し、次の順序で実行する。
 
   ```yaml
-  - uses: supabase/setup-cli@v1
+  - uses: supabase/setup-cli@v2
   - run: npm ci --no-audit
     working-directory: app
   - run: npx playwright install --with-deps chromium

--- a/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
+++ b/docs/superpowers/plans/2026-08-01-codex-cloud-development.md
@@ -1,0 +1,388 @@
+# Codex Cloud リモート開発環境 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Volunty を Codex Cloud で設計・実装・検証し、feature ブランチから `main` 向け Pull Request を作成できるリモート開発環境を構築する。
+
+**Architecture:** Codex Cloud は Node.js 22 の setup/maintenance script を使って依存関係と Prisma Client を準備し、Cloud 内で lint、UT、build を実行する。Pull Request 作成後は GitHub Actions がローカル Supabase と Playwright E2E を含む検証を行い、Vercel は feature ブランチへの push ごとに Preview をデプロイする。Codex Cloud は `main` をマージせず、マージは人間が行う。
+
+**Tech Stack:** Bash、Node.js 22、npm、Prisma 7、Next.js 16、Vitest、Playwright、Supabase CLI、GitHub Actions、Vercel Preview
+
+## Global Constraints
+
+- 作業ブランチは `codex/<topic>` とし、Pull Request の base は `main` とする。
+- Node.js は 22.12 以上の 22 系を使用する。
+- Cloud setup/maintenance は `app/` で `npm ci --no-audit` と `npm run db:generate` を実行する。
+- Cloud setup/maintenance は `.env.local` をコピーせず、Docker、Supabase local、開発サーバー、本番 migration を起動しない。
+- feature ブランチへの push は Vercel Preview の自動デプロイ対象とする。
+- Pull Request の CI は lint、UT、build、ローカル Supabase を使った E2E を実行する。
+- 本番 DB URL、Supabase service role key、OAuth secret、Vercel tokenを Codex Cloud に登録しない。
+- `main` の branch protection、required checks、人間によるマージを維持する。
+- 既存の `.serena/project.yml` の変更はコミット対象に含めない。
+
+## File Map
+
+| ファイル | 役割 |
+| --- | --- |
+| `.codex/cloud/common.sh` | setup/maintenance 共通の Node.js 検証と npm/Prisma セットアップ関数 |
+| `.codex/cloud/setup.sh` | Codex Cloud 初回コンテナのセットアップ entrypoint |
+| `.codex/cloud/maintenance.sh` | キャッシュ済みコンテナ再開時の maintenance entrypoint |
+| `.codex/cloud/cloud-scripts.test.sh` | Cloud script の呼び出し順序、Node.js制約、外部サービス非起動を検証 |
+| `.github/scripts/prepare-e2e-env.sh` | Supabase CLI のローカル出力から `app/.env.local` を一時生成 |
+| `.github/scripts/prepare-e2e-env.test.sh` | E2E環境ファイル生成の決定的な検証 |
+| `.github/workflows/ci.yml` | main向けPRのquality/E2E必須チェック |
+| `AGENTS.md` | Cloud作業、ブランチ、PR、テスト完了条件の指示 |
+| `docs/branch-workflow.md` | Vercel Preview と main向けPRを反映したブランチ運用 |
+| `docs/codex-cloud.md` | Cloud、GitHub、Vercel の設定手順と依頼テンプレート |
+
+---
+
+### Task 1: Codex Cloud setup / maintenance scripts
+
+**Files:**
+- Create: `.codex/cloud/common.sh`
+- Create: `.codex/cloud/setup.sh`
+- Create: `.codex/cloud/maintenance.sh`
+- Test: `.codex/cloud/cloud-scripts.test.sh`
+
+**Interfaces:**
+- `common.sh` exports `codex_cloud_setup_dependencies(repo_root)`; setup と maintenance はこの関数だけを entrypoint から呼び出す。
+- `setup.sh` と `maintenance.sh` はリポジトリルートを `git rev-parse --show-toplevel` から解決し、common関数の終了コードをそのまま返す。
+- テストは一時リポジトリと fake `node`/`npm` を用い、実際の依存関係や `.env.local` に依存しない。
+
+- [ ] **Step 1: 失敗するシェルテストを書く**
+
+  `cloud-scripts.test.sh` に次のケースを実装する。
+
+  - Node.js `v22.12.0` で setup を実行すると `npm ci --no-audit`、`npm run db:generate` の順に呼ばれる。
+  - maintenance でも同じ2コマンドが呼ばれる。
+  - Node.js `v20.19.0` と `v22.11.0` はエラー終了し、npmを呼ばない。
+  - fake `docker`、fake `supabase`、fake `.env.local` が存在しても、それらを呼ばず・読み込まない。
+  - `app/package.json` がない一時リポジトリは明確なエラーを出して終了する。
+
+  テストの検証骨子は次の形式にする。
+
+  ```bash
+  assert_contains "$call_log" "npm ci --no-audit"
+  assert_contains "$call_log" "npm run db:generate"
+  assert_not_contains "$call_log" "docker"
+  assert_not_contains "$call_log" "supabase"
+  ```
+
+- [ ] **Step 2: テストが期待どおり RED になることを確認する**
+
+  ```bash
+  bash .codex/cloud/cloud-scripts.test.sh
+  ```
+
+  Expected: `common.sh`、setup、maintenance がまだ存在しないため、セットアップ呼び出しの検証で失敗する。
+
+- [ ] **Step 3: 共通セットアップ関数を実装する**
+
+  `common.sh` は `set -euo pipefail` を有効にし、次の順序で処理する。
+
+  ```bash
+  require_node_22() {
+    local version major minor
+    version="$(node --version)"
+    major="${version#v}"
+    major="${major%%.*}"
+    minor="${version#v*.}"
+    minor="${minor%%.*}"
+    if [ "$major" != "22" ] || [ "$minor" -lt 12 ]; then
+      printf 'Node.js 22.12+ が必要です: %s\n' "$version" >&2
+      return 1
+    fi
+  }
+
+  codex_cloud_setup_dependencies() {
+    local repo_root="$1"
+    local app_dir="$repo_root/app"
+    [ -f "$app_dir/package.json" ] || return 1
+    require_node_22
+    cd "$app_dir"
+    npm ci --no-audit
+    npm run db:generate
+  }
+  ```
+
+  実装ではバージョン解析の入力を `v22.12.0` の形式に限定し、Node.js/npmが存在しない場合はコマンド名を含む日本語エラーを出す。
+
+- [ ] **Step 4: setup と maintenance の entrypoint を実装する**
+
+  両ファイルは `SCRIPT_DIR` を基準に `common.sh` を読み込み、次を実行する。
+
+  ```bash
+  repo_root="$(git rev-parse --show-toplevel)"
+  # shellcheck source=common.sh
+  . "$script_dir/common.sh"
+  codex_cloud_setup_dependencies "$repo_root"
+  ```
+
+  setup/maintenance間で処理を複製せず、`bash .codex/cloud/setup.sh` と `bash .codex/cloud/maintenance.sh` のどちらからでも同じ結果になるようにする。
+
+- [ ] **Step 5: テストを GREEN にして script を commit する**
+
+  ```bash
+  bash .codex/cloud/cloud-scripts.test.sh
+  bash -n .codex/cloud/common.sh .codex/cloud/setup.sh .codex/cloud/maintenance.sh
+  git add .codex/cloud
+  git commit -m "feat: add Codex Cloud setup scripts"
+  ```
+
+  Expected: `cloud scripts tests passed`、bash syntax success。
+
+### Task 2: Pull Request CI とローカル Supabase E2E
+
+**Files:**
+- Create: `.github/scripts/prepare-e2e-env.sh`
+- Test: `.github/scripts/prepare-e2e-env.test.sh`
+- Create: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- `prepare-e2e-env.sh` は第1引数の status file（`supabase status -o env` の shell assignment ファイル）を読み、リポジトリの `app/.env.local` を生成する。
+- 生成する変数は `NEXT_PUBLIC_SUPABASE_URL`、`NEXT_PUBLIC_SUPABASE_ANON_KEY`、`SUPABASE_SERVICE_ROLE_KEY`、`DATABASE_URL`、`DIRECT_URL`、`E2E_AUTH_ENABLED=true`、`E2E_TEST_USER_PASSWORD=volunty-e2e-password` とする。
+- CI は `pull_request` の `main` base のみを対象にし、quality job と e2e job を独立した required check にする。
+
+- [ ] **Step 1: E2E環境生成の失敗テストを書く**
+
+  fake status file に次の値を置き、生成ファイルの値と機密情報のログ非出力を検証する。
+
+  ```bash
+  API_URL="http://127.0.0.1:54321"
+  ANON_KEY="local-anon-key"
+  SERVICE_ROLE_KEY="local-service-role-key"
+  DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+  ```
+
+  `prepare-e2e-env.test.sh` は `app/.env.local` の各キーを assert し、stdout/stderr に `local-service-role-key` が出ていないことを assert する。
+
+- [ ] **Step 2: テストを実行して RED を確認する**
+
+  ```bash
+  bash .github/scripts/prepare-e2e-env.test.sh
+  ```
+
+  Expected: helper未実装のため生成ファイルが存在せず失敗する。
+
+- [ ] **Step 3: E2E環境生成 helper を実装する**
+
+  helper は `set -euo pipefail`、`mktemp`、`trap` を使い、status file を shell source した後、値の存在を検証して `app/.env.local` へ書き出す。statusの内容や生成した秘密値はログへ出さない。
+
+  ```bash
+  : "${API_URL:?Supabase API_URL is missing}"
+  : "${ANON_KEY:?Supabase ANON_KEY is missing}"
+  : "${SERVICE_ROLE_KEY:?Supabase SERVICE_ROLE_KEY is missing}"
+  : "${DB_URL:?Supabase DB_URL is missing}"
+
+  umask 077
+  cat > "$repo_root/app/.env.local" <<EOF
+  NEXT_PUBLIC_SUPABASE_URL=$API_URL
+  NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+  SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY
+  DATABASE_URL=$DB_URL
+  DIRECT_URL=$DB_URL
+  E2E_AUTH_ENABLED=true
+  E2E_TEST_USER_PASSWORD=volunty-e2e-password
+  EOF
+  ```
+
+- [ ] **Step 4: helperを GREEN にする**
+
+  ```bash
+  bash .github/scripts/prepare-e2e-env.test.sh
+  bash -n .github/scripts/prepare-e2e-env.sh
+  ```
+
+  Expected: generated env assertions pass and secret value is not printed.
+
+- [ ] **Step 5: quality job を追加する**
+
+  `.github/workflows/ci.yml` に `pull_request` と `main` base filter、`ubuntu-latest`、`actions/checkout@v4`、`actions/setup-node@v4`（Node 22、`app/package-lock.json` cache）を追加する。quality job は次を独立 step として実行する。
+
+  ```yaml
+  - run: npm ci --no-audit
+    working-directory: app
+  - run: npm run db:generate
+    working-directory: app
+  - run: npm run lint
+    working-directory: app
+  - run: npm test
+    working-directory: app
+  - run: npm run build
+    working-directory: app
+  ```
+
+- [ ] **Step 6: E2E job を追加する**
+
+  E2E job は Node/npm、Supabase CLI、依存関係、Chromiumを準備し、次の順序で実行する。
+
+  ```yaml
+  - uses: supabase/setup-cli@v1
+  - run: npm ci --no-audit
+    working-directory: app
+  - run: npx playwright install --with-deps chromium
+    working-directory: app
+  - run: supabase start
+  - run: supabase status -o env > "$RUNNER_TEMP/supabase.env"
+  - run: bash .github/scripts/prepare-e2e-env.sh "$RUNNER_TEMP/supabase.env"
+  - run: supabase migration up --local
+  - run: npm run test:e2e
+    working-directory: app
+  ```
+
+  `if: always()` の artifact step で `app/playwright-report`、`app/test-results` を `actions/upload-artifact@v4` に保存し、最後に `supabase stop --no-backup` を実行する。actionのmajor versionは実装時に公式 actionの現行安定版を確認して固定する。
+
+- [ ] **Step 7: CI構文を検証して commit する**
+
+  ```bash
+  bash .github/scripts/prepare-e2e-env.test.sh
+  bash -n .github/scripts/prepare-e2e-env.sh
+  actionlint .github/workflows/ci.yml
+  git add .github/scripts .github/workflows/ci.yml
+  git commit -m "ci: add main pull request checks"
+  ```
+
+  `actionlint` が利用できない場合は、YAML parserで構文を確認し、最終報告に未実行理由を記載する。
+
+### Task 3: Cloud運用指示とブランチ運用ドキュメント
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/branch-workflow.md`
+- Create: `docs/codex-cloud.md`
+
+**Interfaces:**
+- AGENTS.md はリポジトリ全体に適用される短い制約だけを持ち、詳細手順は `docs/codex-cloud.md` に置く。
+- branch-workflow.md は現行Vercel設定を記録し、`codex/<topic> → main` のPRを標準フローとする。
+- codex-cloud.md はCloud/GitHub/Vercelの画面設定と依頼テンプレートを一つの入口にする。
+
+- [ ] **Step 1: ドキュメント更新内容を先に検証する**
+
+  既存文書の `preview` 中継、feature pushのデプロイ記述、main直接push禁止の箇所を `rg` で列挙し、既存の本番DB migration説明を削除しないことを確認する。
+
+  ```bash
+  rg -n "preview|main|Vercel|直接push|Production DB Migration" AGENTS.md docs/branch-workflow.md
+  ```
+
+- [ ] **Step 2: AGENTS.md を更新する**
+
+  次の短いルールを運用ルールへ追加する。
+
+  - 作業ブランチは `codex/<topic>`、Pull Requestのbaseは `main`。
+  - feature pushのVercel Previewを確認してからPRを完成扱いにする。
+  - Codex Cloudは `main` へ直接pushせず、マージは人間が行う。
+  - CI必須チェックと `volunty-test-completion-gate` の結果をPR本文へ記載する。
+
+- [ ] **Step 3: branch-workflow.md を現行設定へ修正する**
+
+  `feature/*` と `codex/*` のpushでVercel Previewが作成されること、PRのbaseを `main` とすること、main mergeでProductionへデプロイされることを表と手順へ反映する。`preview` ブランチは既存利用者向けの説明として残す場合も、標準フローの必須中継地点として記載しない。
+
+- [ ] **Step 4: codex-cloud.md を作成する**
+
+  次の章を日本語で記載する。
+
+  1. Cloud Environment作成（repository、Node.js 22、setup、maintenance）
+  2. Agent internet accessの最小設定
+  3. 登録可能な非秘密環境変数と登録禁止の本番secret
+  4. GitHubのmain branch protectionとrequired checks
+  5. Codex Code Review / Automatic reviews
+  6. Vercel Previewの確認（feature pushをIgnored Build Stepで除外しない）
+  7. Cloud依頼テンプレート
+  8. CI失敗時の同じPRブランチへの修正手順
+
+  依頼テンプレートは次を含める。
+
+  ```text
+  Issue #123を対応してください。
+  まず設計案を提示し、承認されるまで実装しないでください。
+  実装計画の承認後、codex/cloud-setup ブランチで実装してください。
+  必要なUT/E2Eを追加・実行し、Vercel Previewを確認したうえでmain向けPRを作成してください。
+  mainへのマージは行わないでください。
+  ```
+
+- [ ] **Step 5: ドキュメントを検証して commit する**
+
+  ```bash
+  git diff --check
+  rg -n "codex/<topic>|main向け|Preview|mainへの直接push|マージは人間" AGENTS.md docs/branch-workflow.md docs/codex-cloud.md
+  git add AGENTS.md docs/branch-workflow.md docs/codex-cloud.md
+  git commit -m "docs: document Codex Cloud workflow"
+  ```
+
+### Task 4: リモート設定と最終検証
+
+**Files:**
+- Verify: `.codex/environments/default.toml`（ローカルCodex App用として保持）
+- Verify: `.codex/cloud/setup.sh`
+- Verify: `.codex/cloud/maintenance.sh`
+- Verify: `.github/workflows/ci.yml`
+- Verify: `docs/codex-cloud.md`
+
+**Interfaces:**
+- Codex Cloud Environment設定はリポジトリ内ファイルではなく、Codex設定画面へ登録する。
+- GitHub branch protection、Codex Code Review、Vercel Git設定は外部サービス側の設定であり、production secretの値は取得・表示しない。
+
+- [ ] **Step 1: Cloud Environmentを登録する**
+
+  Codex設定画面で repository `seikatu-gakari/volunty` を選び、Node.js 22、次のsetup/maintenanceを登録する。
+
+  ```text
+  Setup: bash .codex/cloud/setup.sh
+  Maintenance: bash .codex/cloud/maintenance.sh
+  ```
+
+  Agent internet accessはoffを基本にし、必要時だけ依存関係用のGET/HEAD/OPTIONSに限定する。本番secretは登録しない。
+
+- [ ] **Step 2: GitHub settingsを確認する**
+
+  `main` にPull Request必須、required checks、force push禁止、branch deletion禁止、未解決review禁止を設定する。Codex Code ReviewとAutomatic reviewsを有効化する。自動マージは無効のままにする。
+
+- [ ] **Step 3: Vercel settingsを確認する**
+
+  feature/codexブランチのpushがPreviewデプロイ対象であることを確認する。Ignored Build Stepにmain/preview以外をskipする条件が残っている場合は、現在のVercel設定と矛盾するため、変更前にユーザーへ確認する。
+
+- [ ] **Step 4: ローカルで設定資産を検証する**
+
+  ```bash
+  bash .codex/cloud/cloud-scripts.test.sh
+  bash .github/scripts/prepare-e2e-env.test.sh
+  bash -n .codex/cloud/common.sh .codex/cloud/setup.sh .codex/cloud/maintenance.sh
+  bash -n .github/scripts/prepare-e2e-env.sh
+  cd app && npm run lint
+  cd app && npm test
+  cd app && npm run build
+  ```
+
+- [ ] **Step 5: E2Eを実行する**
+
+  Docker、Supabase CLI、`.env.local` が利用できる場合だけ、プロジェクトルートで次を実行する。
+
+  ```bash
+  make e2e
+  ```
+
+  実行できない場合は、コマンド、失敗理由、CIでの実行状態を最終報告に分けて記載し、E2E成功を確認するまで完了宣言しない。
+
+- [ ] **Step 6: Cloudから検証PRを作成する**
+
+  小さな変更または設定ブランチで、Cloudが `codex/<topic>` をpushし、Vercel Previewを作成し、`main` 向けPRを作成することを確認する。CI/Codex Reviewが起動し、Cloudが `main` をマージできないことを確認する。
+
+- [ ] **Step 7: 最終状態を記録する**
+
+  ```bash
+  git status --short
+  git diff main...HEAD --stat
+  git log --oneline --decorate -8
+  ```
+
+  `.serena/project.yml` の既存変更を除き、設定資産、テスト、ドキュメントだけが意図したコミットに含まれることを確認する。
+
+## Test Completion Gate
+
+| 区分 | 判定 | 追加・更新するテスト | 最終結果 |
+| --- | --- | --- | --- |
+| UT | 必須相当 | `.codex/cloud/cloud-scripts.test.sh`、`.github/scripts/prepare-e2e-env.test.sh`（決定的なShell設定ロジック） | Task 1/2 と最終検証で実行 |
+| E2E | 必須 | 既存 `make e2e` を GitHub Actions の `ci.yml` で実行（アプリのユーザーフロー変更は行わない） | CI成功を確認するまで未完了 |
+
+ドキュメントのみの Task 3 はUT/E2E適用外だが、最終的なCloud運用変更がPR作成とCIに影響するため、Task 4で実際の設定資産とCIを検証する。

--- a/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
+++ b/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
@@ -123,6 +123,7 @@ Codex Cloud の初回セットアップから呼び出す。
 - Runtime: Node.js 22
 - Setup command: `bash .codex/cloud/setup.sh`
 - Maintenance command: `bash .codex/cloud/maintenance.sh`
+- Environment variable: `TZ=Asia/Tokyo`（`datetime-local` の解釈をローカルと揃える）
 - Agent internet access: 原則 off。タスク中の調査に必要な場合だけ、信頼できるドメインと `GET`、`HEAD`、`OPTIONS` に限定する。
 - Environment variables: テスト・build に必要な非秘密値だけを登録する。
 - Secrets: 依存関係の取得など setup phase だけで必要な資格情報に限定する。本番 Supabase、Vercel、本番 DB の資格情報は登録しない。

--- a/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
+++ b/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
@@ -9,7 +9,7 @@ Volunty の設計、実装、検証、Pull Request 作成を Codex Cloud で完�
 
 - Codex Cloud がリポジトリをチェックアウトし、依存関係と Prisma Client を再現可能に準備できる。
 - Codex Cloud が設計書と実装計画を作成し、承認後に実装できる。
-- Codex Cloud が変更内容に応じて lint、UT、build を実行できる。
+- Codex Cloud が変更内容に応じて lint、UT、`npm run build -- --webpack` を実行できる。
 - Pull Request 上の GitHub Actions が lint、UT、build、E2E を実行できる。
 - Codex Cloud が feature ブランチから `main` 向け Pull Request を作成できる。
 - feature ブランチへの push で Vercel Preview が自動デプロイされる。
@@ -180,7 +180,7 @@ Codex Cloud の Secrets は setup phase 後にエージェント環境から除�
 
 - `cd app && npm run lint`
 - `cd app && npm test`
-- `cd app && npm run build`
+- `cd app && npm run build -- --webpack`
 - `make e2e`
 
 E2E は GitHub Actions での成功を最終判定とし、Codex Cloud 内で Docker が使えるかどうかに完了条件を依存させない。

--- a/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
+++ b/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
@@ -3,7 +3,7 @@
 ## 目的
 
 Volunty の設計、実装、検証、Pull Request 作成を Codex Cloud で完結できるようにする。
-`preview` および `main` へのマージは人間が GitHub 上で行い、Codex Cloud には本番環境の変更権限を与えない。
+`main` へのマージは人間が GitHub 上で行い、Codex Cloud には本番環境の変更権限を与えない。
 
 ## 成功条件
 
@@ -11,8 +11,9 @@ Volunty の設計、実装、検証、Pull Request 作成を Codex Cloud で完�
 - Codex Cloud が設計書と実装計画を作成し、承認後に実装できる。
 - Codex Cloud が変更内容に応じて lint、UT、build を実行できる。
 - Pull Request 上の GitHub Actions が lint、UT、build、E2E を実行できる。
-- Codex Cloud が feature ブランチから `preview` 向け Pull Request を作成できる。
-- Codex Cloud は `preview` または `main` をマージせず、`main` へ直接 push しない。
+- Codex Cloud が feature ブランチから `main` 向け Pull Request を作成できる。
+- feature ブランチへの push で Vercel Preview が自動デプロイされる。
+- Codex Cloud は `main` をマージせず、`main` へ直接 push しない。
 - 本番 Supabase、Vercel、本番データベースのシークレットを Codex Cloud に登録しない。
 
 ## 採用方式
@@ -21,10 +22,11 @@ Codex Cloud と GitHub Actions の分担方式を採用する。
 
 | 担当 | 責務 |
 | --- | --- |
-| Codex Cloud | 要件整理、設計、実装計画、実装、lint、UT、build、feature ブランチへの push、`preview` 向け Pull Request 作成 |
+| Codex Cloud | 要件整理、設計、実装計画、実装、lint、UT、build、feature ブランチへの push、`main` 向け Pull Request 作成 |
 | GitHub Actions | Pull Request ごとの lint、UT、build、ローカル Supabase を使った Playwright E2E |
 | Codex Code Review | Pull Request の自動レビューと重大な問題の指摘 |
-| 人間 | 設計・実装計画の承認、Pull Request レビュー、`preview` と `main` へのマージ判断 |
+| Vercel | feature ブランチへの push ごとの Preview デプロイ |
+| 人間 | 設計・実装計画の承認、Preview 確認、Pull Request レビュー、`main` へのマージ判断 |
 
 Codex Cloud の標準環境で Docker を利用できることに依存しない。Docker を必要とする Supabase E2E は GitHub-hosted runner で実行する。
 
@@ -37,11 +39,11 @@ Codex Cloud の標準環境で Docker を利用できることに依存しない
 5. 人間が実装計画を承認する。
 6. Codex Cloud が `codex/<topic>` ブランチで実装する。
 7. Codex Cloud が変更に必要な UT/E2E を判定し、Cloud 内で lint、UT、build を実行する。
-8. Codex Cloud が `preview` 向け Pull Request を作成する。
-9. GitHub Actions が lint、UT、build、E2E を実行し、Codex Code Review がレビューする。
-10. 不合格の場合、Codex Cloud が同じ Pull Request のブランチを修正する。
-11. 全必須チェックの成功後、人間が Pull Request を `preview` へマージする。
-12. プレビュー確認後、人間が `preview` から `main` への Pull Request をマージする。
+8. feature ブランチへの push を契機に、Vercel が Preview を自動デプロイする。
+9. Codex Cloud が `main` 向け Pull Request を作成する。
+10. GitHub Actions が lint、UT、build、E2E を実行し、Codex Code Review がレビューする。
+11. 不合格の場合、Codex Cloud が同じ Pull Request のブランチを修正する。
+12. 全必須チェックの成功と Preview の確認後、人間が Pull Request を `main` へマージする。
 
 ## リポジトリ変更
 
@@ -68,7 +70,7 @@ Codex Cloud の初回セットアップから呼び出す。
 
 ### `.github/workflows/ci.yml`
 
-`preview` または `main` 向け Pull Request で実行する。
+`main` 向け Pull Request で実行する。
 
 - Node.js 22 を使用する。
 - `app/package-lock.json` をキーに npm cache を利用する。
@@ -86,10 +88,19 @@ Codex Cloud の初回セットアップから呼び出す。
 
 - 複数段階の変更は、設計承認、実装計画承認、実装の順に進める。
 - 作業ブランチは `codex/<topic>` とする。
-- 開発 Pull Request の base は `preview` とする。
-- `preview` と `main` は人間だけがマージする。
+- 開発 Pull Request の base は `main` とする。
+- `main` は人間だけがマージする。
 - `main` への直接 push、production migration、本番シークレットの参照を禁止する。
 - `volunty-test-completion-gate` に基づく検証結果を Pull Request 本文へ記載する。
+
+### `docs/branch-workflow.md`
+
+現在の Vercel 設定と Codex Cloud 運用に合わせて更新する。
+
+- feature ブランチへの push でも Vercel Preview が自動デプロイされることを明記する。
+- 標準フローを `codex/<topic>` から `main` への Pull Request に変更する。
+- `preview` ブランチを必須の中継地点として扱わない。
+- `main` のマージは人間が行うことを維持する。
 
 ### `docs/codex-cloud.md`
 
@@ -101,7 +112,7 @@ Codex Cloud の初回セットアップから呼び出す。
 - setup script と maintenance script の登録コマンド
 - Agent internet access の最小権限
 - Codex Code Review と Automatic reviews の有効化
-- `preview` と `main` の branch protection および required checks
+- `main` の branch protection および required checks
 - Cloud へ渡してよい環境変数と、登録禁止の本番シークレット
 - 設計から Pull Request 作成までの依頼テンプレート
 - キャッシュリセットと失敗時の切り分け手順
@@ -128,7 +139,7 @@ Codex Cloud の Secrets は setup phase 後にエージェント環境から除�
 
 ### Branch protection
 
-`preview` と `main` に次を設定する。
+`main` に次を設定する。
 
 - Pull Request 経由の変更を必須にする。
 - CI の lint、UT、build、E2E を required checks にする。
@@ -145,7 +156,7 @@ Codex Cloud の Secrets は setup phase 後にエージェント環境から除�
 - E2E は GitHub Actions 内に作成したローカル Supabase のみを利用する。
 - fork 由来 Pull Request へ機密情報を渡さない。
 - Agent internet access は必要なタスクだけ個別に拡張し、無制限アクセスを既定にしない。
-- Codex Cloud に `preview`／`main` のマージや本番デプロイの責務を持たせない。
+- Codex Cloud に `main` のマージや本番デプロイの責務を持たせない。
 
 ## エラー処理
 
@@ -177,13 +188,14 @@ E2E は GitHub Actions での成功を最終判定とし、Codex Cloud 内で Do
 ### 運用確認
 
 - Codex Cloud から小さな検証ブランチを作成する。
-- `preview` 向け Pull Request を作成する。
+- feature ブランチへの push で Vercel Preview が作成されることを確認する。
+- `main` 向け Pull Request を作成する。
 - required checks と Codex Review が自動起動することを確認する。
-- Codex Cloud が `preview` または `main` をマージできない運用になっていることを確認する。
+- Codex Cloud が `main` をマージしない運用になっていることを確認する。
 
 ## 対象外
 
-- Codex Cloud による `preview` または `main` の自動マージ
+- Codex Cloud による `main` の自動マージ
 - 本番 DB migration の変更
 - Vercel の本番・Preview環境変数の変更
 - 本番 Supabase を使ったテスト

--- a/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
+++ b/docs/superpowers/specs/2026-08-01-codex-cloud-development-design.md
@@ -1,0 +1,198 @@
+# Codex Cloud リモート開発環境 設計
+
+## 目的
+
+Volunty の設計、実装、検証、Pull Request 作成を Codex Cloud で完結できるようにする。
+`preview` および `main` へのマージは人間が GitHub 上で行い、Codex Cloud には本番環境の変更権限を与えない。
+
+## 成功条件
+
+- Codex Cloud がリポジトリをチェックアウトし、依存関係と Prisma Client を再現可能に準備できる。
+- Codex Cloud が設計書と実装計画を作成し、承認後に実装できる。
+- Codex Cloud が変更内容に応じて lint、UT、build を実行できる。
+- Pull Request 上の GitHub Actions が lint、UT、build、E2E を実行できる。
+- Codex Cloud が feature ブランチから `preview` 向け Pull Request を作成できる。
+- Codex Cloud は `preview` または `main` をマージせず、`main` へ直接 push しない。
+- 本番 Supabase、Vercel、本番データベースのシークレットを Codex Cloud に登録しない。
+
+## 採用方式
+
+Codex Cloud と GitHub Actions の分担方式を採用する。
+
+| 担当 | 責務 |
+| --- | --- |
+| Codex Cloud | 要件整理、設計、実装計画、実装、lint、UT、build、feature ブランチへの push、`preview` 向け Pull Request 作成 |
+| GitHub Actions | Pull Request ごとの lint、UT、build、ローカル Supabase を使った Playwright E2E |
+| Codex Code Review | Pull Request の自動レビューと重大な問題の指摘 |
+| 人間 | 設計・実装計画の承認、Pull Request レビュー、`preview` と `main` へのマージ判断 |
+
+Codex Cloud の標準環境で Docker を利用できることに依存しない。Docker を必要とする Supabase E2E は GitHub-hosted runner で実行する。
+
+## 開発フロー
+
+1. 人間が Codex Cloud に Issue、目的、完了条件を渡す。
+2. Codex Cloud が関連コードとドキュメントを調査し、設計案を提示する。
+3. 人間が設計を承認する。
+4. Codex Cloud が実装計画を提示する。
+5. 人間が実装計画を承認する。
+6. Codex Cloud が `codex/<topic>` ブランチで実装する。
+7. Codex Cloud が変更に必要な UT/E2E を判定し、Cloud 内で lint、UT、build を実行する。
+8. Codex Cloud が `preview` 向け Pull Request を作成する。
+9. GitHub Actions が lint、UT、build、E2E を実行し、Codex Code Review がレビューする。
+10. 不合格の場合、Codex Cloud が同じ Pull Request のブランチを修正する。
+11. 全必須チェックの成功後、人間が Pull Request を `preview` へマージする。
+12. プレビュー確認後、人間が `preview` から `main` への Pull Request をマージする。
+
+## リポジトリ変更
+
+### `.codex/cloud/setup.sh`
+
+Codex Cloud の初回セットアップから呼び出す。
+
+- リポジトリルートと `app/package.json` を検証する。
+- Node.js 22 系と npm が利用可能であることを検証する。
+- `app/` で `npm ci --no-audit` を実行する。
+- `npm run db:generate` を実行する。
+- Docker、Supabase、開発サーバーは起動しない。
+- 本番またはローカルの `.env.local` をコピーしない。
+
+### `.codex/cloud/maintenance.sh`
+
+キャッシュ済み Cloud 環境の再利用時に呼び出す。
+
+- `app/package-lock.json` に従って `npm ci --no-audit` を再実行する。
+- Prisma Client を再生成する。
+- データベース migration や seed は実行しない。
+
+初回 setup と maintenance は同じ依存関係セットアップ関数を共有し、処理差による環境ドリフトを避ける。
+
+### `.github/workflows/ci.yml`
+
+`preview` または `main` 向け Pull Request で実行する。
+
+- Node.js 22 を使用する。
+- `app/package-lock.json` をキーに npm cache を利用する。
+- `npm ci` と Prisma Client 生成を行う。
+- lint、UT、Next.js build をそれぞれ独立した結果として確認できるようにする。
+- E2E ジョブでは Supabase CLI と Chromium を準備し、既存の `make e2e` 相当を非対話で実行する。
+- E2E 失敗時は Playwright の HTML report、trace、screenshot を artifact として保存する。
+- Pull Request 由来のコードに本番データベース用 GitHub Secrets を渡さない。
+
+ジョブ構成は、依存関係インストールを重複させすぎず、どの検証が失敗したか判別できる粒度にする。正確な action バージョンは実装時に公式リポジトリの現行リリースを確認して固定する。
+
+### `AGENTS.md`
+
+既存ルールへ Codex Cloud 用の次の制約を短く追加する。
+
+- 複数段階の変更は、設計承認、実装計画承認、実装の順に進める。
+- 作業ブランチは `codex/<topic>` とする。
+- 開発 Pull Request の base は `preview` とする。
+- `preview` と `main` は人間だけがマージする。
+- `main` への直接 push、production migration、本番シークレットの参照を禁止する。
+- `volunty-test-completion-gate` に基づく検証結果を Pull Request 本文へ記載する。
+
+### `docs/codex-cloud.md`
+
+人間が Codex Cloud と GitHub で行う設定を記録する。
+
+- GitHub リポジトリ接続
+- Cloud Environment の作成
+- Node.js 22 の選択
+- setup script と maintenance script の登録コマンド
+- Agent internet access の最小権限
+- Codex Code Review と Automatic reviews の有効化
+- `preview` と `main` の branch protection および required checks
+- Cloud へ渡してよい環境変数と、登録禁止の本番シークレット
+- 設計から Pull Request 作成までの依頼テンプレート
+- キャッシュリセットと失敗時の切り分け手順
+
+## Cloud Environment 設定
+
+- Repository: `seikatu-gakari/volunty`
+- Runtime: Node.js 22
+- Setup command: `bash .codex/cloud/setup.sh`
+- Maintenance command: `bash .codex/cloud/maintenance.sh`
+- Agent internet access: 原則 off。タスク中の調査に必要な場合だけ、信頼できるドメインと `GET`、`HEAD`、`OPTIONS` に限定する。
+- Environment variables: テスト・build に必要な非秘密値だけを登録する。
+- Secrets: 依存関係の取得など setup phase だけで必要な資格情報に限定する。本番 Supabase、Vercel、本番 DB の資格情報は登録しない。
+
+Codex Cloud の Secrets は setup phase 後にエージェント環境から除外される。このため、テスト中に必要な資格情報を Secret として渡す設計にはしない。
+
+## GitHub 設定
+
+### Codex
+
+- Codex Cloud から `seikatu-gakari/volunty` へアクセスできるようにする。
+- Codex Code Review を有効化する。
+- Automatic reviews を有効化する。
+
+### Branch protection
+
+`preview` と `main` に次を設定する。
+
+- Pull Request 経由の変更を必須にする。
+- CI の lint、UT、build、E2E を required checks にする。
+- 未解決レビューがある場合のマージを禁止する。
+- force push と branch deletion を禁止する。
+- 自動マージは有効化しない。
+
+`main` へのマージ後に既存の `Production DB Migration` が動く点は変更しない。Codex Cloud から本番 migration workflow を手動実行しない。
+
+## セキュリティ境界
+
+- `app/.env.local` をコミット、アップロード、Cloud へコピーしない。
+- Codex Cloud に本番 DB URL、Supabase service role key、OAuth secret、Vercel token を登録しない。
+- E2E は GitHub Actions 内に作成したローカル Supabase のみを利用する。
+- fork 由来 Pull Request へ機密情報を渡さない。
+- Agent internet access は必要なタスクだけ個別に拡張し、無制限アクセスを既定にしない。
+- Codex Cloud に `preview`／`main` のマージや本番デプロイの責務を持たせない。
+
+## エラー処理
+
+- setup 失敗時は Node.js、npm、`npm ci`、Prisma generate のどこで失敗したかを明示する。
+- maintenance 失敗時はキャッシュを信用せず、Cloud Environment の Reset cache 手順を案内する。
+- lint、UT、build、E2E は失敗した区分を個別に報告する。
+- E2E 失敗時は artifact を保存し、trace と screenshot から再現箇所を確認できるようにする。
+- Codex Cloud が Pull Request を作成できない場合は、GitHub 接続権限と対象ブランチの書き込み権限を確認し、`main` への権限緩和で回避しない。
+
+## 検証方針
+
+### 設定・スクリプト
+
+- `bash -n` で setup と maintenance の構文を検証する。
+- ShellCheck が利用可能なら実行する。
+- Cloud 相当の Linux／Node.js 22 環境で setup を実行する。
+- setup と maintenance の再実行が成功することを確認する。
+- setup が `.env.local`、Docker、Supabase、本番 migration を必要としないことを確認する。
+
+### アプリケーション
+
+- `cd app && npm run lint`
+- `cd app && npm test`
+- `cd app && npm run build`
+- `make e2e`
+
+E2E は GitHub Actions での成功を最終判定とし、Codex Cloud 内で Docker が使えるかどうかに完了条件を依存させない。
+
+### 運用確認
+
+- Codex Cloud から小さな検証ブランチを作成する。
+- `preview` 向け Pull Request を作成する。
+- required checks と Codex Review が自動起動することを確認する。
+- Codex Cloud が `preview` または `main` をマージできない運用になっていることを確認する。
+
+## 対象外
+
+- Codex Cloud による `preview` または `main` の自動マージ
+- 本番 DB migration の変更
+- Vercel の本番・Preview環境変数の変更
+- 本番 Supabase を使ったテスト
+- ローカル Codex App 用 `.codex/environments/default.toml` の置き換え
+- 既存の Docker Compose／Supabase ローカル開発フローの変更
+
+## 公式資料
+
+- [Codex Cloud environments](https://learn.chatgpt.com/docs/environments/cloud-environment.md)
+- [Codex agent internet access](https://learn.chatgpt.com/docs/cloud/internet-access.md)
+- [Codex code review in GitHub](https://learn.chatgpt.com/docs/third-party/github.md)
+- [openai/codex-universal](https://github.com/openai/codex-universal)

--- a/supabase/rls.test.sh
+++ b/supabase/rls.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+
+for command_name in initdb pg_ctl psql; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'skip: %s is required for the local RLS test\n' "$command_name"
+    exit 0
+  fi
+done
+
+test_tmp="$(mktemp -d)"
+data_dir="$test_tmp/data"
+database_name="volunty_rls_test"
+port=$((55432 + RANDOM % 1000))
+database_url="postgresql://$(id -un)@127.0.0.1:$port/$database_name"
+
+cleanup() {
+  pg_ctl -D "$data_dir" -m fast stop >/dev/null 2>&1 || true
+  rm -rf "$test_tmp"
+}
+trap cleanup EXIT
+
+initdb -D "$data_dir" --no-locale --encoding=UTF8 --auth=trust >/dev/null
+pg_ctl -D "$data_dir" -o "-p $port" -l "$test_tmp/postgres.log" -w start >/dev/null
+
+createdb_command="$(command -v createdb || true)"
+if [ -z "$createdb_command" ]; then
+  psql "$database_url" -v ON_ERROR_STOP=1 -X -c "CREATE DATABASE $database_name" >/dev/null
+else
+  "$createdb_command" -p "$port" "$database_name" >/dev/null
+fi
+
+psql "$database_url" -v ON_ERROR_STOP=1 -X <<'SQL' >/dev/null
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE ROLE anon NOLOGIN;
+CREATE ROLE authenticated NOLOGIN;
+CREATE SCHEMA auth;
+CREATE TABLE auth.users (
+  instance_id uuid,
+  id uuid PRIMARY KEY,
+  aud text,
+  role text,
+  email text,
+  encrypted_password text,
+  email_confirmed_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  raw_app_meta_data jsonb,
+  raw_user_meta_data jsonb,
+  confirmation_token text,
+  recovery_token text,
+  email_change_token_new text,
+  email_change text
+);
+CREATE TABLE auth.identities (
+  id uuid,
+  user_id uuid,
+  provider_id text,
+  identity_data jsonb,
+  provider text,
+  last_sign_in_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz
+);
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid;
+$$;
+GRANT USAGE ON SCHEMA auth TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION auth.uid() TO anon, authenticated;
+SQL
+
+psql "$database_url" -v ON_ERROR_STOP=1 -X -f "$repo_root/supabase/migrations/20260704000000_init.sql" >/dev/null
+psql "$database_url" -v ON_ERROR_STOP=1 -X -f "$repo_root/supabase/migrations/20260708000000_add_message_templates.sql" >/dev/null
+psql "$database_url" -v ON_ERROR_STOP=1 -X -f "$repo_root/supabase/seed.sql" >/dev/null
+
+psql "$database_url" -v ON_ERROR_STOP=1 -X <<'SQL'
+BEGIN;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '33333333-3333-3333-3333-333333333333', true);
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.t_matching_candidate (
+      id, participant_id, opportunity_id, status, message,
+      applied_at, status_changed_at, created_at, updated_at
+    ) VALUES (
+      '77777777-7777-7777-7777-777777777777',
+      '33333333-3333-3333-3333-333333333333',
+      'f2222222-2222-2222-2222-222222222222',
+      'accepted', '不正な初期状態', NOW(), NOW(), NOW(), NOW()
+    );
+    RAISE EXCEPTION 'participant accepted INSERT unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.t_matching_candidate (
+      id, participant_id, opportunity_id, status, message,
+      applied_at, status_changed_at, created_at, updated_at
+    ) VALUES (
+      '88888888-8888-8888-8888-888888888888',
+      '33333333-3333-3333-3333-333333333333',
+      'f2222222-2222-2222-2222-222222222222',
+      'completed', '不正な初期状態', NOW(), NOW(), NOW(), NOW()
+    );
+    RAISE EXCEPTION 'participant completed INSERT unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+INSERT INTO public.t_matching_candidate (
+  id, participant_id, opportunity_id, status, message,
+  applied_at, status_changed_at, created_at, updated_at
+) VALUES (
+  '66666666-6666-6666-6666-666666666666',
+  '33333333-3333-3333-3333-333333333333',
+  'f2222222-2222-2222-2222-222222222222',
+  'applied', '正常な応募', NOW(), NOW(), NOW(), NOW()
+);
+
+SELECT set_config('request.jwt.claim.sub', '44444444-4444-4444-4444-444444444444', true);
+
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.t_matching_candidate
+    SET participant_id = '22222222-2222-2222-2222-222222222222'
+    WHERE id = '66666666-6666-6666-6666-666666666666';
+    RAISE EXCEPTION 'organization participant_id UPDATE unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.t_matching_candidate
+    SET opportunity_id = 'f1111111-1111-1111-1111-111111111111'
+    WHERE id = '66666666-6666-6666-6666-666666666666';
+    RAISE EXCEPTION 'organization opportunity_id UPDATE unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+UPDATE public.t_matching_candidate
+SET status = 'accepted', status_changed_at = NOW(), updated_at = NOW()
+WHERE id = '66666666-6666-6666-6666-666666666666';
+
+UPDATE public.t_matching_candidate
+SET status = 'completed', status_changed_at = NOW(), updated_at = NOW()
+WHERE id = '66666666-6666-6666-6666-666666666666';
+
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.t_matching_candidate
+    SET status = 'completed', status_changed_at = NOW(), updated_at = NOW()
+    WHERE participant_id = '11111111-1111-1111-1111-111111111111'
+      AND opportunity_id = 'f1111111-1111-1111-1111-111111111111'
+      AND status = 'applied';
+    RAISE EXCEPTION 'organization applied-to-completed UPDATE unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.t_matching_candidate
+    SET status = 'cancelled', status_changed_at = NOW(), updated_at = NOW()
+    WHERE participant_id = '11111111-1111-1111-1111-111111111111'
+      AND opportunity_id = 'f1111111-1111-1111-1111-111111111111'
+      AND status = 'applied';
+    RAISE EXCEPTION 'organization applied-to-cancelled UPDATE unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+ROLLBACK;
+SQL
+
+printf 'RLS DML tests passed\n'

--- a/supabase/rls.test.sh
+++ b/supabase/rls.test.sh
@@ -120,6 +120,14 @@ INSERT INTO public.m_opportunity (
     'dddddddd-dddd-dddd-dddd-dddddddddddd',
     'RLS テスト締切済み案件',
     'published', NOW() - INTERVAL '2 days', CURRENT_DATE - 1, NOW(), NOW()
+  ),
+  (
+    'fc000000-0000-0000-0000-000000000000',
+    'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    'RLS テスト JST 境界案件',
+    'published', NOW() - INTERVAL '1 minute',
+    (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Tokyo')::date - 1,
+    NOW(), NOW()
   );
 
 INSERT INTO public.t_recommendation_log (
@@ -144,6 +152,29 @@ INSERT INTO public.t_recommendation_log (
     'f2222222-2222-2222-2222-222222222222',
     1, 0.7, '{}'::jsonb, '[]'::jsonb, 'rls-test', NOW()
   );
+SQL
+
+# INSERT ポリシーが参照するユーザー状態・参加者プロフィールの境界を用意する。
+psql "$database_url" -v ON_ERROR_STOP=1 -X <<'SQL' >/dev/null
+INSERT INTO public.m_user (
+  id, role, is_active, suspended_at, created_at, updated_at
+) VALUES
+  (
+    '66666666-6666-6666-6666-666666666666',
+    'participant', true, NULL, NOW(), NOW()
+  ),
+  (
+    '77777777-7777-7777-7777-777777777777',
+    'participant', false, NOW(), NOW(), NOW()
+  );
+
+INSERT INTO public.m_participant_profile (
+  id, user_id, name, birthday, region, public_profile, created_at, updated_at
+) VALUES (
+  'dddddddd-7777-7777-7777-777777777777',
+  '77777777-7777-7777-7777-777777777777',
+  'RLS 無効参加者', '2000-01-01', '東京都', true, NOW(), NOW()
+);
 SQL
 
 psql "$database_url" -v ON_ERROR_STOP=1 -X <<'SQL'
@@ -277,6 +308,113 @@ BEGIN
 END;
 $$;
 
+SELECT set_config('request.jwt.claim.sub', '44444444-4444-4444-4444-444444444444', true);
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.t_matching_candidate (
+      id, participant_id, opportunity_id, status, message,
+      applied_at, status_changed_at, created_at, updated_at
+    ) VALUES (
+      '90000000-0000-0000-0000-000000000031',
+      '44444444-4444-4444-4444-444444444444',
+      'f8888888-8888-8888-8888-888888888888',
+      'applied', 'organization user',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00'
+    );
+    RAISE EXCEPTION 'organization user INSERT unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+SELECT set_config('request.jwt.claim.sub', '66666666-6666-6666-6666-666666666666', true);
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.t_matching_candidate (
+      id, participant_id, opportunity_id, status, message,
+      applied_at, status_changed_at, created_at, updated_at
+    ) VALUES (
+      '90000000-0000-0000-0000-000000000032',
+      '66666666-6666-6666-6666-666666666666',
+      'f8888888-8888-8888-8888-888888888888',
+      'applied', 'participant without profile',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00'
+    );
+    RAISE EXCEPTION 'participant without profile INSERT unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+SELECT set_config('request.jwt.claim.sub', '77777777-7777-7777-7777-777777777777', true);
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.t_matching_candidate (
+      id, participant_id, opportunity_id, status, message,
+      applied_at, status_changed_at, created_at, updated_at
+    ) VALUES (
+      '90000000-0000-0000-0000-000000000033',
+      '77777777-7777-7777-7777-777777777777',
+      'f8888888-8888-8888-8888-888888888888',
+      'applied', 'inactive participant',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00'
+    );
+    RAISE EXCEPTION 'inactive participant INSERT unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+SELECT set_config('request.jwt.claim.sub', '33333333-3333-3333-3333-333333333333', true);
+
+SET LOCAL TIME ZONE 'Asia/Tokyo';
+SELECT set_config('TimeZone', '-15:00', true);
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.t_matching_candidate (
+      id, participant_id, opportunity_id, status, message,
+      applied_at, status_changed_at, created_at, updated_at
+    ) VALUES (
+      '90000000-0000-0000-0000-000000000041',
+      '33333333-3333-3333-3333-333333333333',
+      'fc000000-0000-0000-0000-000000000000',
+      'applied', 'JST boundary',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00',
+      TIMESTAMP '2000-01-01 00:00:00+00'
+    );
+    RAISE EXCEPTION 'JST-expired opportunity INSERT unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
 INSERT INTO public.t_matching_candidate (
   id, participant_id, opportunity_id, recommendation_log_id,
   status, message, applied_at, status_changed_at, created_at, updated_at
@@ -295,9 +433,32 @@ INSERT INTO public.t_matching_candidate (
   '66666666-6666-6666-6666-666666666666',
   '33333333-3333-3333-3333-333333333333',
   'f2222222-2222-2222-2222-222222222222',
-  'applied', '正常な応募', NOW(), TIMESTAMP '2000-01-01 00:00:00+00',
-  TIMESTAMP '2000-01-01 00:00:00+00', TIMESTAMP '2000-01-01 00:00:00+00'
+  'applied', '正常な応募', TIMESTAMP '2000-01-01 00:00:00+00',
+  TIMESTAMP '2000-01-01 00:00:00+00', TIMESTAMP '2000-01-01 00:00:00+00',
+  TIMESTAMP '2000-01-01 00:00:00+00'
 );
+
+DO $$
+DECLARE
+  applied_at_value timestamptz;
+  status_changed_at_value timestamptz;
+  created_at_value timestamptz;
+  updated_at_value timestamptz;
+BEGIN
+  SELECT applied_at, status_changed_at, created_at, updated_at
+  INTO applied_at_value, status_changed_at_value, created_at_value, updated_at_value
+  FROM public.t_matching_candidate
+  WHERE id = '66666666-6666-6666-6666-666666666666';
+
+  IF applied_at_value IS NULL
+     OR applied_at_value <= TIMESTAMP '2020-01-01 00:00:00+00'
+     OR status_changed_at_value <= TIMESTAMP '2020-01-01 00:00:00+00'
+     OR created_at_value <= TIMESTAMP '2020-01-01 00:00:00+00'
+     OR updated_at_value <= TIMESTAMP '2020-01-01 00:00:00+00' THEN
+    RAISE EXCEPTION 'INSERT timestamps were not set by the database';
+  END IF;
+END;
+$$;
 
 SELECT set_config('request.jwt.claim.sub', '44444444-4444-4444-4444-444444444444', true);
 
@@ -335,7 +496,9 @@ DECLARE
   updated_at_value timestamptz;
 BEGIN
   UPDATE public.t_matching_candidate
-  SET status = 'accepted'
+  SET status = 'accepted',
+      status_changed_at = TIMESTAMP '2000-01-01 00:00:00+00',
+      updated_at = TIMESTAMP '2000-01-01 00:00:00+00'
   WHERE id = '66666666-6666-6666-6666-666666666666';
 
   SELECT status_changed_at, updated_at
@@ -377,7 +540,9 @@ BEGIN
   WHERE id = '66666666-6666-6666-6666-666666666666';
 
   UPDATE public.t_matching_candidate
-  SET status = 'completed'
+  SET status = 'completed',
+      status_changed_at = TIMESTAMP '2000-01-01 00:00:00+00',
+      updated_at = TIMESTAMP '2000-01-01 00:00:00+00'
   WHERE id = '66666666-6666-6666-6666-666666666666';
 
   SELECT status_changed_at
@@ -436,6 +601,26 @@ BEGIN
     'EXECUTE'
   ) THEN
     RAISE EXCEPTION 'trigger function unexpectedly has authenticated EXECUTE';
+  END IF;
+  IF has_function_privilege(
+    'authenticated',
+    'public.matching_candidate_before_insert()',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'insert trigger function unexpectedly has authenticated EXECUTE';
+  END IF;
+  IF NOT has_column_privilege(
+    'authenticated',
+    'public.t_matching_candidate',
+    'status_changed_at',
+    'UPDATE'
+  ) OR NOT has_column_privilege(
+    'authenticated',
+    'public.t_matching_candidate',
+    'updated_at',
+    'UPDATE'
+  ) THEN
+    RAISE EXCEPTION 'Server Action timestamp columns lack authenticated UPDATE privilege';
   END IF;
 END;
 $$;

--- a/supabase/rls.test.sh
+++ b/supabase/rls.test.sh
@@ -125,7 +125,7 @@ INSERT INTO public.m_opportunity (
     'fc000000-0000-0000-0000-000000000000',
     'dddddddd-dddd-dddd-dddd-dddddddddddd',
     'RLS テスト JST 境界案件',
-    'published', NOW() - INTERVAL '1 minute',
+    'published', TIMESTAMP '2000-01-01 00:00:00',
     (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Tokyo')::date - 1,
     NOW(), NOW()
   );
@@ -151,6 +151,12 @@ INSERT INTO public.t_recommendation_log (
     '33333333-3333-3333-3333-333333333333',
     'f2222222-2222-2222-2222-222222222222',
     1, 0.7, '{}'::jsonb, '[]'::jsonb, 'rls-test', NOW()
+  ),
+  (
+    'a4444444-4444-4444-4444-444444444444',
+    '33333333-3333-3333-3333-333333333333',
+    'fc000000-0000-0000-0000-000000000000',
+    1, 0.6, '{}'::jsonb, '[]'::jsonb, 'rls-test', NOW()
   );
 SQL
 
@@ -389,18 +395,75 @@ $$;
 SELECT set_config('request.jwt.claim.sub', '33333333-3333-3333-3333-333333333333', true);
 
 SET LOCAL TIME ZONE 'Asia/Tokyo';
-SELECT set_config('TimeZone', '-15:00', true);
+SELECT set_config('TimeZone', '+15:00', true);
+
+DO $$
+DECLARE
+  boundary_opportunity record;
+  participant_is_valid boolean;
+  recommendation_is_valid boolean;
+BEGIN
+  SELECT status, published_at, end_date
+  INTO boundary_opportunity
+  FROM public.m_opportunity
+  WHERE id = 'fc000000-0000-0000-0000-000000000000';
+
+  IF boundary_opportunity.status <> 'published'::public.opportunity_status
+     OR boundary_opportunity.published_at IS NULL
+     OR boundary_opportunity.published_at > CURRENT_TIMESTAMP THEN
+    RAISE EXCEPTION 'JST boundary opportunity is not otherwise published and public';
+  END IF;
+  IF CURRENT_DATE <> boundary_opportunity.end_date THEN
+    RAISE EXCEPTION 'JST boundary precondition does not satisfy old CURRENT_DATE predicate';
+  END IF;
+  IF (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Tokyo')::date
+       <= boundary_opportunity.end_date THEN
+    RAISE EXCEPTION 'JST boundary precondition is not expired in Asia/Tokyo';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.m_user AS participant_user
+    JOIN public.m_participant_profile AS participant_profile
+      ON participant_profile.user_id = participant_user.id
+    WHERE participant_user.id = auth.uid()
+      AND participant_user.role = 'participant'::public.user_role
+      AND participant_user.is_active IS TRUE
+      AND participant_user.suspended_at IS NULL
+  )
+  INTO participant_is_valid;
+  IF NOT participant_is_valid THEN
+    RAISE EXCEPTION 'JST boundary participant/profile precondition is invalid';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.t_recommendation_log AS recommendation_log
+    WHERE recommendation_log.id =
+        'a4444444-4444-4444-4444-444444444444'
+      AND recommendation_log.user_id = auth.uid()
+      AND recommendation_log.opportunity_id =
+        'fc000000-0000-0000-0000-000000000000'
+  )
+  INTO recommendation_is_valid;
+  IF NOT recommendation_is_valid THEN
+    RAISE EXCEPTION 'JST boundary recommendation precondition is invalid';
+  END IF;
+END;
+$$;
 
 DO $$
 BEGIN
   BEGIN
     INSERT INTO public.t_matching_candidate (
-      id, participant_id, opportunity_id, status, message,
+      id, participant_id, opportunity_id, recommendation_log_id,
+      status, message,
       applied_at, status_changed_at, created_at, updated_at
     ) VALUES (
       '90000000-0000-0000-0000-000000000041',
       '33333333-3333-3333-3333-333333333333',
       'fc000000-0000-0000-0000-000000000000',
+      'a4444444-4444-4444-4444-444444444444',
       'applied', 'JST boundary',
       TIMESTAMP '2000-01-01 00:00:00+00',
       TIMESTAMP '2000-01-01 00:00:00+00',
@@ -414,6 +477,8 @@ BEGIN
   END;
 END;
 $$;
+
+SELECT set_config('TimeZone', 'Asia/Tokyo', true);
 
 INSERT INTO public.t_matching_candidate (
   id, participant_id, opportunity_id, recommendation_log_id,

--- a/supabase/rls.test.sh
+++ b/supabase/rls.test.sh
@@ -16,8 +16,20 @@ data_dir="$test_tmp/data"
 database_name="volunty_rls_test"
 port=$((55432 + RANDOM % 1000))
 database_url="postgresql://$(id -un)@127.0.0.1:$port/$database_name"
+race_a_pid=""
+race_b_pid=""
+race_a_fd=""
 
 cleanup() {
+  if [ -n "$race_a_fd" ]; then
+    eval "exec ${race_a_fd}>&-" || true
+  fi
+  if [ -n "$race_a_pid" ]; then
+    kill "$race_a_pid" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$race_b_pid" ]; then
+    kill "$race_b_pid" >/dev/null 2>&1 || true
+  fi
   pg_ctl -D "$data_dir" -m fast stop >/dev/null 2>&1 || true
   rm -rf "$test_tmp"
 }
@@ -80,6 +92,60 @@ psql "$database_url" -v ON_ERROR_STOP=1 -X -f "$repo_root/supabase/migrations/20
 psql "$database_url" -v ON_ERROR_STOP=1 -X -f "$repo_root/supabase/migrations/20260708000000_add_message_templates.sql" >/dev/null
 psql "$database_url" -v ON_ERROR_STOP=1 -X -f "$repo_root/supabase/seed.sql" >/dev/null
 
+# 応募 RLS の公開条件・推薦ログ所有条件を検証するための一時案件・ログ。
+psql "$database_url" -v ON_ERROR_STOP=1 -X <<'SQL' >/dev/null
+INSERT INTO public.m_opportunity (
+  id, organization_id, title, status, published_at, end_date, created_at, updated_at
+) VALUES
+  (
+    'f8888888-8888-8888-8888-888888888888',
+    'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    'RLS テスト公開案件',
+    'published', NOW() - INTERVAL '1 minute', CURRENT_DATE + 7, NOW(), NOW()
+  ),
+  (
+    'f9999999-9999-9999-9999-999999999999',
+    'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    'RLS テスト下書き案件',
+    'draft', NULL, CURRENT_DATE + 7, NOW(), NOW()
+  ),
+  (
+    'fa000000-0000-0000-0000-000000000000',
+    'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    'RLS テスト公開予約案件',
+    'published', NOW() + INTERVAL '1 day', CURRENT_DATE + 7, NOW(), NOW()
+  ),
+  (
+    'fb000000-0000-0000-0000-000000000000',
+    'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    'RLS テスト締切済み案件',
+    'published', NOW() - INTERVAL '2 days', CURRENT_DATE - 1, NOW(), NOW()
+  );
+
+INSERT INTO public.t_recommendation_log (
+  id, user_id, opportunity_id, rank, total_score,
+  rule_contributions, reasons, matching_rule_version, created_at
+) VALUES
+  (
+    'a1111111-1111-1111-1111-111111111111',
+    '33333333-3333-3333-3333-333333333333',
+    'f8888888-8888-8888-8888-888888888888',
+    1, 0.9, '{}'::jsonb, '[]'::jsonb, 'rls-test', NOW()
+  ),
+  (
+    'a2222222-2222-2222-2222-222222222222',
+    '22222222-2222-2222-2222-222222222222',
+    'f8888888-8888-8888-8888-888888888888',
+    1, 0.8, '{}'::jsonb, '[]'::jsonb, 'rls-test', NOW()
+  ),
+  (
+    'a3333333-3333-3333-3333-333333333333',
+    '33333333-3333-3333-3333-333333333333',
+    'f2222222-2222-2222-2222-222222222222',
+    1, 0.7, '{}'::jsonb, '[]'::jsonb, 'rls-test', NOW()
+  );
+SQL
+
 psql "$database_url" -v ON_ERROR_STOP=1 -X <<'SQL'
 BEGIN;
 
@@ -127,6 +193,101 @@ BEGIN
 END;
 $$;
 
+DO $$
+DECLARE
+  invalid_row record;
+BEGIN
+  FOR invalid_row IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          '90000000-0000-0000-0000-000000000001'::uuid,
+          'f9999999-9999-9999-9999-999999999999'::uuid,
+          'draft opportunity'
+        ),
+        (
+          '90000000-0000-0000-0000-000000000002'::uuid,
+          'fa000000-0000-0000-0000-000000000000'::uuid,
+          'future publication'
+        ),
+        (
+          '90000000-0000-0000-0000-000000000003'::uuid,
+          'fb000000-0000-0000-0000-000000000000'::uuid,
+          'expired opportunity'
+        )
+    ) AS rows(id, opportunity_id, label)
+  LOOP
+    BEGIN
+      INSERT INTO public.t_matching_candidate (
+        id, participant_id, opportunity_id, status, message,
+        applied_at, status_changed_at, created_at, updated_at
+      ) VALUES (
+        invalid_row.id,
+        '33333333-3333-3333-3333-333333333333',
+        invalid_row.opportunity_id,
+        'applied', invalid_row.label, NOW(), NOW(), NOW(), NOW()
+      );
+      RAISE EXCEPTION '% INSERT unexpectedly succeeded', invalid_row.label;
+    EXCEPTION
+      WHEN insufficient_privilege OR check_violation THEN
+        NULL;
+    END;
+  END LOOP;
+END;
+$$;
+
+DO $$
+DECLARE
+  invalid_row record;
+BEGIN
+  FOR invalid_row IN
+    SELECT *
+    FROM (
+      VALUES
+        (
+          '90000000-0000-0000-0000-000000000011'::uuid,
+          'a2222222-2222-2222-2222-222222222222'::uuid,
+          'other participant recommendation'
+        ),
+        (
+          '90000000-0000-0000-0000-000000000012'::uuid,
+          'a3333333-3333-3333-3333-333333333333'::uuid,
+          'different opportunity recommendation'
+        )
+    ) AS rows(id, recommendation_log_id, label)
+  LOOP
+    BEGIN
+      INSERT INTO public.t_matching_candidate (
+        id, participant_id, opportunity_id, recommendation_log_id,
+        status, message, applied_at, status_changed_at, created_at, updated_at
+      ) VALUES (
+        invalid_row.id,
+        '33333333-3333-3333-3333-333333333333',
+        'f8888888-8888-8888-8888-888888888888',
+        invalid_row.recommendation_log_id,
+        'applied', invalid_row.label, NOW(), NOW(), NOW(), NOW()
+      );
+      RAISE EXCEPTION '% INSERT unexpectedly succeeded', invalid_row.label;
+    EXCEPTION
+      WHEN insufficient_privilege OR check_violation THEN
+        NULL;
+    END;
+  END LOOP;
+END;
+$$;
+
+INSERT INTO public.t_matching_candidate (
+  id, participant_id, opportunity_id, recommendation_log_id,
+  status, message, applied_at, status_changed_at, created_at, updated_at
+) VALUES (
+  '90000000-0000-0000-0000-000000000021',
+  '33333333-3333-3333-3333-333333333333',
+  'f8888888-8888-8888-8888-888888888888',
+  'a1111111-1111-1111-1111-111111111111',
+  'applied', 'own recommendation', NOW(), NOW(), NOW(), NOW()
+);
+
 INSERT INTO public.t_matching_candidate (
   id, participant_id, opportunity_id, status, message,
   applied_at, status_changed_at, created_at, updated_at
@@ -134,7 +295,8 @@ INSERT INTO public.t_matching_candidate (
   '66666666-6666-6666-6666-666666666666',
   '33333333-3333-3333-3333-333333333333',
   'f2222222-2222-2222-2222-222222222222',
-  'applied', '正常な応募', NOW(), NOW(), NOW(), NOW()
+  'applied', '正常な応募', NOW(), TIMESTAMP '2000-01-01 00:00:00+00',
+  TIMESTAMP '2000-01-01 00:00:00+00', TIMESTAMP '2000-01-01 00:00:00+00'
 );
 
 SELECT set_config('request.jwt.claim.sub', '44444444-4444-4444-4444-444444444444', true);
@@ -167,13 +329,67 @@ BEGIN
 END;
 $$;
 
-UPDATE public.t_matching_candidate
-SET status = 'accepted', status_changed_at = NOW(), updated_at = NOW()
-WHERE id = '66666666-6666-6666-6666-666666666666';
+DO $$
+DECLARE
+  changed_at timestamptz;
+  updated_at_value timestamptz;
+BEGIN
+  UPDATE public.t_matching_candidate
+  SET status = 'accepted'
+  WHERE id = '66666666-6666-6666-6666-666666666666';
 
-UPDATE public.t_matching_candidate
-SET status = 'completed', status_changed_at = NOW(), updated_at = NOW()
-WHERE id = '66666666-6666-6666-6666-666666666666';
+  SELECT status_changed_at, updated_at
+  INTO changed_at, updated_at_value
+  FROM public.t_matching_candidate
+  WHERE id = '66666666-6666-6666-6666-666666666666';
+
+  IF changed_at <= TIMESTAMP '2020-01-01 00:00:00+00'
+     OR updated_at_value <= TIMESTAMP '2020-01-01 00:00:00+00' THEN
+    RAISE EXCEPTION 'status transition timestamps were not set by the database';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.t_matching_candidate
+    SET status = 'accepted',
+        status_changed_at = TIMESTAMP '2000-01-01 00:00:00+00',
+        updated_at = TIMESTAMP '2000-01-01 00:00:00+00'
+    WHERE id = '66666666-6666-6666-6666-666666666666';
+    RAISE EXCEPTION 'same-status timestamp UPDATE unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+DO $$
+DECLARE
+  previous_changed_at timestamptz;
+  completed_at timestamptz;
+BEGIN
+  SELECT status_changed_at
+  INTO previous_changed_at
+  FROM public.t_matching_candidate
+  WHERE id = '66666666-6666-6666-6666-666666666666';
+
+  UPDATE public.t_matching_candidate
+  SET status = 'completed'
+  WHERE id = '66666666-6666-6666-6666-666666666666';
+
+  SELECT status_changed_at
+  INTO completed_at
+  FROM public.t_matching_candidate
+  WHERE id = '66666666-6666-6666-6666-666666666666';
+
+  IF completed_at <= previous_changed_at THEN
+    RAISE EXCEPTION 'completed status timestamp was not advanced by the database';
+  END IF;
+END;
+$$;
 
 DO $$
 BEGIN
@@ -207,7 +423,145 @@ BEGIN
 END;
 $$;
 
+DO $$
+BEGIN
+  IF to_regprocedure(
+    'public.matching_candidate_status_update_allowed(uuid,public.matching_status)'
+  ) IS NOT NULL THEN
+    RAISE EXCEPTION 'public status oracle function unexpectedly remains';
+  END IF;
+  IF has_function_privilege(
+    'authenticated',
+    'public.matching_candidate_before_update()',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'trigger function unexpectedly has authenticated EXECUTE';
+  END IF;
+END;
+$$;
+
 ROLLBACK;
 SQL
+
+# 2接続で同じ applied 行を競合更新する。接続Aの未コミット UPDATE を
+# idle in transaction として確認してから、接続Bが行ロック待ちになったことを
+# pg_stat_activity で確認し、AをCOMMITする。固定sleepを同期条件にしない。
+race_id="91000000-0000-0000-0000-000000000001"
+psql "$database_url" -v ON_ERROR_STOP=1 -X -c "
+  INSERT INTO public.t_matching_candidate (
+    id, participant_id, opportunity_id, status, message,
+    applied_at, status_changed_at, created_at, updated_at
+  ) VALUES (
+    '$race_id',
+    '33333333-3333-3333-3333-333333333333',
+    'f2222222-2222-2222-2222-222222222222',
+    'applied', '競合テスト', NOW(), NOW(), NOW(), NOW()
+  )
+" >/dev/null
+
+race_fifo="$test_tmp/race-a.sql"
+mkfifo "$race_fifo"
+race_a_url="$database_url?application_name=volunty-rls-race-a"
+psql "$race_a_url" -v ON_ERROR_STOP=1 -X \
+  <"$race_fifo" >"$test_tmp/race-a.log" 2>&1 &
+race_a_pid=$!
+exec {race_a_fd}>"$race_fifo"
+printf '%s\n' \
+  'BEGIN;' \
+  'SET LOCAL ROLE authenticated;' \
+  "SELECT set_config('request.jwt.claim.sub', '44444444-4444-4444-4444-444444444444', true);" \
+  "UPDATE public.t_matching_candidate SET status = 'accepted' WHERE id = '$race_id';" \
+  >&"$race_a_fd"
+
+race_a_ready=false
+for _ in $(seq 1 200); do
+  race_a_state="$(psql "$database_url" -AtX -c "
+    SELECT state
+    FROM pg_stat_activity
+    WHERE application_name = 'volunty-rls-race-a'
+      AND state = 'idle in transaction'
+    LIMIT 1
+  ")"
+  if [ "$race_a_state" = "idle in transaction" ]; then
+    race_a_ready=true
+    break
+  fi
+  sleep 0.01
+done
+if [ "$race_a_ready" != true ]; then
+  printf '競合テストの接続Aが未コミット状態になりませんでした\n' >&2
+  cat "$test_tmp/race-a.log" >&2
+  exit 1
+fi
+
+race_b_url="$database_url?application_name=volunty-rls-race-b"
+psql "$race_b_url" -v ON_ERROR_STOP=1 -X >"$test_tmp/race-b.log" 2>&1 <<SQL &
+BEGIN;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '44444444-4444-4444-4444-444444444444', true);
+DO \$\$
+BEGIN
+  BEGIN
+    UPDATE public.t_matching_candidate
+    SET status = 'declined'
+    WHERE id = '$race_id';
+    RAISE EXCEPTION 'concurrent applied-to-declined UPDATE unexpectedly succeeded';
+  EXCEPTION
+    WHEN insufficient_privilege OR check_violation THEN
+      NULL;
+  END;
+END;
+\$\$;
+COMMIT;
+SQL
+race_b_pid=$!
+
+race_b_waiting=false
+for _ in $(seq 1 200); do
+  race_b_wait_event="$(psql "$database_url" -AtX -c "
+    SELECT COALESCE(wait_event_type, '')
+    FROM pg_stat_activity
+    WHERE application_name = 'volunty-rls-race-b'
+      AND state = 'active'
+    LIMIT 1
+  ")"
+  if [ "$race_b_wait_event" = "Lock" ]; then
+    race_b_waiting=true
+    break
+  fi
+  sleep 0.01
+done
+if [ "$race_b_waiting" != true ]; then
+  printf '競合テストの接続Bが行ロック待ちになりませんでした\n' >&2
+  cat "$test_tmp/race-b.log" >&2
+  exit 1
+fi
+
+printf 'COMMIT;\n' >&"$race_a_fd"
+eval "exec ${race_a_fd}>&-"
+race_a_fd=""
+if ! wait "$race_a_pid"; then
+  printf '競合テストの接続Aが失敗しました\n' >&2
+  cat "$test_tmp/race-a.log" >&2
+  exit 1
+fi
+race_a_pid=""
+
+if ! wait "$race_b_pid"; then
+  printf '競合テストの接続Bが失敗しました\n' >&2
+  cat "$test_tmp/race-b.log" >&2
+  exit 1
+fi
+race_b_pid=""
+
+race_status="$(psql "$database_url" -AtX -c "
+  SELECT status
+  FROM public.t_matching_candidate
+  WHERE id = '$race_id'
+")"
+if [ "$race_status" != "accepted" ]; then
+  printf '競合テスト後のstatusが不正です: %s\n' "$race_status" >&2
+  exit 1
+fi
 
 printf 'RLS DML tests passed\n'

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -166,6 +166,16 @@ CREATE POLICY "参加者は応募を作成可能"
     AND status = 'applied'::public.matching_status
     AND EXISTS (
       SELECT 1
+      FROM public.m_user AS participant_user
+      JOIN public.m_participant_profile AS participant_profile
+        ON participant_profile.user_id = participant_user.id
+      WHERE participant_user.id = public.t_matching_candidate.participant_id
+        AND participant_user.role = 'participant'::public.user_role
+        AND participant_user.is_active IS TRUE
+        AND participant_user.suspended_at IS NULL
+    )
+    AND EXISTS (
+      SELECT 1
       FROM public.m_opportunity AS opportunity
       WHERE opportunity.id = public.t_matching_candidate.opportunity_id
         AND opportunity.status = 'published'::public.opportunity_status
@@ -173,7 +183,8 @@ CREATE POLICY "参加者は応募を作成可能"
         AND opportunity.published_at <= CURRENT_TIMESTAMP
         AND (
           opportunity.end_date IS NULL
-          OR opportunity.end_date >= CURRENT_DATE
+          OR opportunity.end_date >=
+            (CURRENT_TIMESTAMP AT TIME ZONE 'Asia/Tokyo')::date
         )
     )
     AND (
@@ -187,6 +198,34 @@ CREATE POLICY "参加者は応募を作成可能"
       )
     )
   );
+
+-- PostgREST経由のINSERTでクライアントが監査日時を偽装できないようにする。
+CREATE OR REPLACE FUNCTION public.matching_candidate_before_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  -- Prismaの直接接続（RLS対象外ロール）はE2E fixtureの状態投入を継続する。
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  NEW.applied_at := clock_timestamp();
+  NEW.status_changed_at := clock_timestamp();
+  NEW.created_at := clock_timestamp();
+  NEW.updated_at := clock_timestamp();
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.matching_candidate_before_insert() FROM PUBLIC;
+DROP TRIGGER IF EXISTS matching_candidate_before_insert
+  ON public.t_matching_candidate;
+CREATE TRIGGER matching_candidate_before_insert
+  BEFORE INSERT ON public.t_matching_candidate
+  FOR EACH ROW
+  EXECUTE FUNCTION public.matching_candidate_before_insert();
 
 -- 団体による応募ステータス変更は、画面で定義した遷移だけを許可する。
 -- RLSポリシーのスナップショットではなく、UPDATEのOLD/NEWを比較する
@@ -293,7 +332,7 @@ GRANT SELECT, INSERT, UPDATE ON public.m_opportunity TO authenticated;
 GRANT SELECT ON public.t_recommendation_log TO authenticated;
 GRANT SELECT, INSERT ON public.t_matching_candidate TO authenticated;
 REVOKE UPDATE ON public.t_matching_candidate FROM authenticated;
-GRANT UPDATE (status)
+GRANT UPDATE (status, status_changed_at, updated_at)
   ON public.t_matching_candidate TO authenticated;
 
 -- ============================================

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -161,7 +161,53 @@ CREATE POLICY "団体は自分の案件の応募を閲覧可能"
 
 CREATE POLICY "参加者は応募を作成可能"
   ON public.t_matching_candidate FOR INSERT
-  WITH CHECK (participant_id = auth.uid());
+  WITH CHECK (
+    participant_id = auth.uid()
+    AND status = 'applied'::public.matching_status
+  );
+
+-- 団体による応募ステータス変更は、画面で定義した遷移だけを許可する。
+-- SECURITY DEFINER で更新前の行を参照し、authenticated ロールの直接更新で
+-- applied → completed のような不正な遷移が成立しないようにする。
+CREATE OR REPLACE FUNCTION public.matching_candidate_status_update_allowed(
+  candidate_id uuid,
+  next_status public.matching_status
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.t_matching_candidate AS candidate
+    WHERE candidate.id = candidate_id
+      AND (
+        candidate.status = next_status
+        OR (
+          candidate.status = 'applied'::public.matching_status
+          AND next_status IN (
+            'accepted'::public.matching_status,
+            'declined'::public.matching_status
+          )
+        )
+        OR (
+          candidate.status = 'accepted'::public.matching_status
+          AND next_status = 'completed'::public.matching_status
+        )
+      )
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.matching_candidate_status_update_allowed(
+  uuid,
+  public.matching_status
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.matching_candidate_status_update_allowed(
+  uuid,
+  public.matching_status
+) TO authenticated;
 
 CREATE POLICY "団体は応募ステータスを更新可能"
   ON public.t_matching_candidate FOR UPDATE
@@ -171,6 +217,14 @@ CREATE POLICY "団体は応募ステータスを更新可能"
       JOIN public.m_organization_profile org ON o.organization_id = org.id
       WHERE org.user_id = auth.uid()
     )
+  )
+  WITH CHECK (
+    opportunity_id IN (
+      SELECT o.id FROM public.m_opportunity o
+      JOIN public.m_organization_profile org ON o.organization_id = org.id
+      WHERE org.user_id = auth.uid()
+    )
+    AND public.matching_candidate_status_update_allowed(id, status)
   );
 
 -- t_participation_feedback: 当事者（応募した参加者・対象案件の団体）のみ閲覧可能
@@ -204,7 +258,10 @@ GRANT SELECT ON public.t_diagnosis_result TO authenticated;
 GRANT SELECT ON public.m_organization_profile TO anon, authenticated;
 GRANT SELECT ON public.m_opportunity TO anon;
 GRANT SELECT, INSERT, UPDATE ON public.m_opportunity TO authenticated;
-GRANT SELECT, INSERT, UPDATE ON public.t_matching_candidate TO authenticated;
+GRANT SELECT, INSERT ON public.t_matching_candidate TO authenticated;
+REVOKE UPDATE ON public.t_matching_candidate FROM authenticated;
+GRANT UPDATE (status, status_changed_at, updated_at)
+  ON public.t_matching_candidate TO authenticated;
 
 -- ============================================
 -- テストデータ（ローカル開発専用）

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -164,50 +164,83 @@ CREATE POLICY "参加者は応募を作成可能"
   WITH CHECK (
     participant_id = auth.uid()
     AND status = 'applied'::public.matching_status
+    AND EXISTS (
+      SELECT 1
+      FROM public.m_opportunity AS opportunity
+      WHERE opportunity.id = public.t_matching_candidate.opportunity_id
+        AND opportunity.status = 'published'::public.opportunity_status
+        AND opportunity.published_at IS NOT NULL
+        AND opportunity.published_at <= CURRENT_TIMESTAMP
+        AND (
+          opportunity.end_date IS NULL
+          OR opportunity.end_date >= CURRENT_DATE
+        )
+    )
+    AND (
+      recommendation_log_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.t_recommendation_log AS recommendation_log
+        WHERE recommendation_log.id = public.t_matching_candidate.recommendation_log_id
+          AND recommendation_log.user_id = auth.uid()
+          AND recommendation_log.opportunity_id = public.t_matching_candidate.opportunity_id
+      )
+    )
   );
 
 -- 団体による応募ステータス変更は、画面で定義した遷移だけを許可する。
--- SECURITY DEFINER で更新前の行を参照し、authenticated ロールの直接更新で
--- applied → completed のような不正な遷移が成立しないようにする。
-CREATE OR REPLACE FUNCTION public.matching_candidate_status_update_allowed(
-  candidate_id uuid,
-  next_status public.matching_status
-)
-RETURNS boolean
-LANGUAGE sql
-STABLE
-SECURITY DEFINER
-SET search_path = public
+-- RLSポリシーのスナップショットではなく、UPDATEのOLD/NEWを比較する
+-- BEFOREトリガーで競合時も遷移を再検証する。
+CREATE OR REPLACE FUNCTION public.matching_candidate_before_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
 AS $$
-  SELECT EXISTS (
-    SELECT 1
-    FROM public.t_matching_candidate AS candidate
-    WHERE candidate.id = candidate_id
-      AND (
-        candidate.status = next_status
-        OR (
-          candidate.status = 'applied'::public.matching_status
-          AND next_status IN (
-            'accepted'::public.matching_status,
-            'declined'::public.matching_status
-          )
-        )
-        OR (
-          candidate.status = 'accepted'::public.matching_status
-          AND next_status = 'completed'::public.matching_status
-        )
+BEGIN
+  -- Prismaの直接接続（RLS対象外ロール）はE2E fixtureの状態投入を継続する。
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status = OLD.status THEN
+    IF NEW.status_changed_at IS DISTINCT FROM OLD.status_changed_at
+       OR NEW.updated_at IS DISTINCT FROM OLD.updated_at THEN
+      RAISE EXCEPTION '応募ステータスが変わらない更新では日時を変更できません'
+        USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NOT (
+    (
+      OLD.status = 'applied'::public.matching_status
+      AND NEW.status IN (
+        'accepted'::public.matching_status,
+        'declined'::public.matching_status
       )
-  );
+    )
+    OR (
+      OLD.status = 'accepted'::public.matching_status
+      AND NEW.status = 'completed'::public.matching_status
+    )
+  ) THEN
+    RAISE EXCEPTION '応募ステータスの遷移が許可されていません'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  NEW.status_changed_at := clock_timestamp();
+  NEW.updated_at := clock_timestamp();
+  RETURN NEW;
+END;
 $$;
 
-REVOKE ALL ON FUNCTION public.matching_candidate_status_update_allowed(
-  uuid,
-  public.matching_status
-) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.matching_candidate_status_update_allowed(
-  uuid,
-  public.matching_status
-) TO authenticated;
+REVOKE ALL ON FUNCTION public.matching_candidate_before_update() FROM PUBLIC;
+DROP TRIGGER IF EXISTS matching_candidate_before_update
+  ON public.t_matching_candidate;
+CREATE TRIGGER matching_candidate_before_update
+  BEFORE UPDATE ON public.t_matching_candidate
+  FOR EACH ROW
+  EXECUTE FUNCTION public.matching_candidate_before_update();
 
 CREATE POLICY "団体は応募ステータスを更新可能"
   ON public.t_matching_candidate FOR UPDATE
@@ -224,7 +257,6 @@ CREATE POLICY "団体は応募ステータスを更新可能"
       JOIN public.m_organization_profile org ON o.organization_id = org.id
       WHERE org.user_id = auth.uid()
     )
-    AND public.matching_candidate_status_update_allowed(id, status)
   );
 
 -- t_participation_feedback: 当事者（応募した参加者・対象案件の団体）のみ閲覧可能
@@ -258,9 +290,10 @@ GRANT SELECT ON public.t_diagnosis_result TO authenticated;
 GRANT SELECT ON public.m_organization_profile TO anon, authenticated;
 GRANT SELECT ON public.m_opportunity TO anon;
 GRANT SELECT, INSERT, UPDATE ON public.m_opportunity TO authenticated;
+GRANT SELECT ON public.t_recommendation_log TO authenticated;
 GRANT SELECT, INSERT ON public.t_matching_candidate TO authenticated;
 REVOKE UPDATE ON public.t_matching_candidate FROM authenticated;
-GRANT UPDATE (status, status_changed_at, updated_at)
+GRANT UPDATE (status)
   ON public.t_matching_candidate TO authenticated;
 
 -- ============================================

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -190,6 +190,23 @@ CREATE POLICY "当事者は参加評価を閲覧可能"
   );
 
 -- ============================================
+-- PostgREST ロール権限（ローカル開発用）
+-- ============================================
+-- RLS は行単位の認可であり、PostgreSQL のテーブル権限を付与しないと
+-- anon / authenticated ロールから REST API を利用できない。
+-- 付与対象はアプリが Supabase クライアント経由で参照・更新するテーブルに限定する。
+GRANT USAGE ON SCHEMA public TO anon, authenticated;
+
+GRANT SELECT ON public.m_user TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.m_participant_profile TO authenticated;
+GRANT SELECT ON public.t_diagnosis_result TO authenticated;
+
+GRANT SELECT ON public.m_organization_profile TO anon, authenticated;
+GRANT SELECT ON public.m_opportunity TO anon;
+GRANT SELECT, INSERT, UPDATE ON public.m_opportunity TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.t_matching_candidate TO authenticated;
+
+-- ============================================
 -- テストデータ（ローカル開発専用）
 -- ============================================
 -- 固定 UUID を使用してリレーションの整合性を確保する。


### PR DESCRIPTION
## 概要

Codex Cloudで設計・実装・検証・PR作成までを安全に回せるVolunty向け開発基盤を整備し、Cloudのツール構成をMCPブリッジ方式からCLI優先方式へ更新します。

## 背景・目的

Codex Cloudとローカル環境の実行境界を明確にし、Cloudでは認証情報を持つMCPブリッジに依存せず、固定版の用途別CLIと既存GitHub/Vercel連携を使用します。ローカルのネイティブMCP設定は維持します。

## 対応内容

- Node.js 22のCloud setup/maintenanceと、`main`向けPRのquality/E2E CIを整備
- Context7 CLI `0.5.7`とVercel CLI `58.7.1`を必要時だけ導入し、同版では再インストールしない処理を追加
- Cloudから`mcpc`を除外し、Playwright、Prisma、Vitest、ESLint、TypeScript、`rg` / `git grep`を直接使用する運用を文書化
- ローカルSupabaseを使う決定的なE2E環境生成と、feature pushによるVercel Preview運用を整備
- 本番シークレット、Vercel token、GitHub MCP tokenをCloudやtracked fileへ登録しない境界を明記

## 主な設計判断

- Cloud内の調査・検証は用途別CLIを直接使用し、ローカルのネイティブMCP設定は変更しません。
- Context7/Vercel CLIは固定versionを検証し、missing・異versionの場合だけglobal installします。
- Docker/Supabaseを必要とするE2EはGitHub-hosted runnerで実行し、Cloud setupでは外部サービスを起動しません。
- `main`へのmergeは人間が行い、このPRではmergeしません。

## 受け入れ条件との対応

- [x] Cloud Setup/Maintenanceに`mcpc`のインストール処理がない
- [x] 固定版`ctx7` CLIが必要時だけインストールされ、同版では再インストールされない
- [x] Vercel CLI固定版導入と回帰テストを維持
- [x] CLI優先方式とセキュリティ境界を共通指示・skill・運用文書へ反映
- [x] `bash -n`、ShellCheck、`git diff --check`が成功
- [x] 差分に秘密情報およびローカルMCP設定の変更がない
- [x] `ctx7 library` / `ctx7 docs`の実呼び出しが成功
- [x] 元checkoutの既存dirty変更と`.serena/project.yml`を変更・commitしていない

## 検証

- `bash .codex/cloud/common.test.sh`: 成功
- `bash .codex/cloud/cloud-scripts.test.sh`: 成功
- `bash .github/scripts/prepare-e2e-env.test.sh`: 成功
- `bash supabase/rls.test.sh`: 成功（PostgreSQL 14で3回、競合更新とRLS/DML境界を検証）
- `bash -n .codex/cloud/common.sh .codex/cloud/common.test.sh .codex/cloud/cloud-scripts.test.sh .codex/cloud/setup.sh .codex/cloud/maintenance.sh`: 成功
- `shellcheck`（Cloud関連shell 5ファイル）: 成功
- `actionlint .github/workflows/ci.yml`: 成功
- `cd app && npm run db:generate`: 成功
- `cd app && npm run lint`: 成功
- `cd app && npm test`: 成功（83 files / 519 tests）
- `cd app && npm run build -- --webpack`（CI同等のplaceholder local環境変数）: 成功
- `ctx7 --version` / `ctx7 library` / `ctx7 docs`: 成功（`0.5.7`）

## レビュー結果

- Local `final_reviewer`: 承認（HEAD: `176c828dd859dab0eed453dda3bb7c474f4935a1`）
- GitHub Codex review（1回のみ）: 指摘対応済み（review HEAD: `46508a97e740a4b322b9a095e855678144e0bc50`、fix HEAD: `176c828dd859dab0eed453dda3bb7c474f4935a1`）
- Required checks: すべて成功（current HEADの`quality` / `e2e`、run `31127288421` attempt 2）

## 残存リスク

Vercel PreviewとGitHub Actionsの`quality` / `e2e`は最新HEADで成功しました。`supabase/rls.test.sh`は今回ローカルで実行しましたが、現行CI workflowからは直接呼び出していません。本番・Preview環境変数および本番データは変更していません。

Closes #196
